### PR TITLE
RTM compat and fixes

### DIFF
--- a/NewVegasReloaded/Main.cpp
+++ b/NewVegasReloaded/Main.cpp
@@ -47,6 +47,12 @@ extern "C" {
 				TheShaderManager->Effects.AmbientOcclusion->bNVAOLoaded = true;
 			}			
 
+			HMODULE hRTM = GetModuleHandle(L"RealTimeMenus.dll");
+			if (hRTM) {
+				Logger::Log("Real Time Menus found, initializing functions");
+				TheGameMenuManager->IsLiveMenu = (GameMenuManager::MenuPauseState(__cdecl*)(uint32_t, bool, bool))GetProcAddress(hRTM, "IsLiveMenu");
+			}
+
 			// Make sure all SLS vertex shaders pass and update EyePosition.
 			ShadowLightShader::EnableEyePositionForAllPasses();
 

--- a/src/NewVegas/Base.h
+++ b/src/NewVegas/Base.h
@@ -60,8 +60,6 @@ public:
 		static const UInt32 Method	= 0x007134D0;
 	};
 	struct Shadows {
-		static const UInt32 RenderShadowMapHook			= 0x00870C39;
-		static const UInt32 RenderShadowMapReturn		= 0x00870C41;
 		static const UInt32 RenderShadowMap1Hook		= 0x0087084E;
 		static const UInt32 RenderShadowMap1Return		= 0x00870856;
 		static const UInt32 AddCastShadowFlagHook		= 0x0050DD06;

--- a/src/NewVegas/Hooks/Hooks.cpp
+++ b/src/NewVegas/Hooks/Hooks.cpp
@@ -55,9 +55,9 @@ void AttachHooks() {
 	SafeWriteJump(Jumpers::DetectorWindow::ConsoleCommandHook, (UInt32)DetectorWindowConsoleCommandHook);
 	SafeWriteCall(Jumpers::DetectorWindow::SetNodeName, (UInt32)DetectorWindowSetNodeName);
 	SafeWriteJump(Jumpers::RenderInterface::Hook, (UInt32)RenderInterfaceHook);
-	SafeWriteJump(Jumpers::Shadows::RenderShadowMapHook, (UInt32)RenderShadowMapHook);
-	//	SafeWriteJump(Jumpers::Shadows::RenderShadowMap1Hook,		(UInt32)RenderShadowMap1Hook);
-	SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook, (UInt32)AddCastShadowFlagHook);
+	SafeWriteJump(0x871290, (UInt32)RenderShadowMapHook);
+	//SafeWriteJump(Jumpers::Shadows::RenderShadowMap1Hook,		(UInt32)RenderShadowMap1Hook);
+	//SafeWriteJump(Jumpers::Shadows::AddCastShadowFlagHook, (UInt32)AddCastShadowFlagHook);
 	SafeWriteJump(Jumpers::Shadows::LeavesNodeNameHook, (UInt32)LeavesNodeNameHook);
 	SafeWriteCall(Jumpers::MainMenuMusic::Fix1, (UInt32)MainMenuMusicFix);
 	SafeWriteCall(Jumpers::MainMenuMusic::Fix2, (UInt32)MainMenuMusicFix);

--- a/src/NewVegas/Hooks/Render.cpp
+++ b/src/NewVegas/Hooks/Render.cpp
@@ -134,7 +134,7 @@ void(__cdecl* ProcessImageSpaceShaders)(NiDX9Renderer*, BSRenderedTexture*, BSRe
 void __cdecl ProcessImageSpaceShadersHook(NiDX9Renderer* Renderer, BSRenderedTexture* SourceTarget, BSRenderedTexture* DestinationTarget) {
 	bool bLiveRenderedMenu = false; // FORenderedMenu, FOPipBoyManager
 	bool bLive3DMenu = false; // Normal menus, but 3D, lockpick etc
-	if (*reinterpret_cast<bool*>(0x11DEA29) && TheGameMenuManager->IsLiveMenu && InterfaceManager->currentMode != 1) {
+	if (TESMain::IsMenuBackgroundReady() && TheGameMenuManager->IsLiveMenu && InterfaceManager->currentMode != 1) {
 		const bool bLockPickMenu = LockPickMenu::GetSingleton() && TheGameMenuManager->IsLiveMenu(Menu::kMenuType_LockPick, false, false) == GameMenuManager::MENU_LIVE;
 		const bool bPipBoyLive = InterfaceManager->IsPipBoyOpen() && TheGameMenuManager->IsLiveMenu(Menu::kMenuType_BigFour, false, false) == GameMenuManager::MenuPauseState::MENU_LIVE;
 		const bool bRenderedMenuLive = InterfaceManager->pRenderedMenu && TheGameMenuManager->IsLiveMenu(InterfaceManager->menuStack[0], false, false) == GameMenuManager::MenuPauseState::MENU_LIVE;

--- a/src/NewVegas/Hooks/Shadows.cpp
+++ b/src/NewVegas/Hooks/Shadows.cpp
@@ -1,14 +1,8 @@
 #pragma once
 
-__declspec(naked) void RenderShadowMapHook() {
-
-	__asm {
-		pushad
-		mov		ecx, TheShadowManager
-		call	ShadowManager::RenderShadowMaps
-		popad
-		jmp		Jumpers::Shadows::RenderShadowMapReturn
-	}
+void __fastcall RenderShadowMapHook(void* apThis) {
+	TheShadowManager->RenderShadowMaps();
+	CdeclCall(0x871A50);
 }
 
 static void AddCastShadowFlag(TESObjectREFR* Ref, TESObjectLIGH* Light, NiPointLight* LightPoint) {

--- a/src/NewVegas/Hooks/Shadows.h
+++ b/src/NewVegas/Hooks/Shadows.h
@@ -1,4 +1,3 @@
 #pragma once
-void RenderShadowMapHook();
-void AddCastShadowFlagHook();
+void __fastcall RenderShadowMapHook(void* apThis);
 void LeavesNodeNameHook();

--- a/src/NewVegas/nvse/Game.h
+++ b/src/NewVegas/nvse/Game.h
@@ -4689,6 +4689,13 @@ public:
 };
 assert(sizeof(Menu) == 0x28);
 
+class LockPickMenu : public Menu{
+public:
+	static LockPickMenu* GetSingleton() {
+		return *reinterpret_cast<LockPickMenu**>(0x11DA204);
+	}
+};
+
 class HUDMainMenu : public Menu {
 public:
 	struct QueuedMessage {
@@ -5292,7 +5299,7 @@ public:
 	UInt32					unk160;				// 160
 	UInt32					unk164;				// 164
 	UInt32					unk168;				// 168
-	void*					unk16C;				// 16C
+	void*					pRenderedMenu;		// 16C
 	UInt32					unk170;				// 170
 	void*					pipboyManager;		// 174 FOPipboyManager*
 	UInt32					unk178;				// 178
@@ -5306,7 +5313,7 @@ public:
 	UInt32					pipBoyMode;			// 4BC
 	UInt32					unk4C0[48];			// 4C0
 
-	UInt8					getIsMenuOpen() { return pipBoyMode == 3; };
+	UInt8					IsPipBoyOpen() { return pipBoyMode == 3; };
 };
 assert(sizeof(MenuInterfaceManager) == 0x580);
 

--- a/src/NewVegas/nvse/Game.h
+++ b/src/NewVegas/nvse/Game.h
@@ -5738,3 +5738,10 @@ public:
 		return *(NiNode**)0x11D8690;
 	}
 };
+
+class TESMain {
+public:
+	static bool IsMenuBackgroundReady() {
+		return *reinterpret_cast<bool*>(0x11DEA29);
+	}
+};

--- a/src/core/GameMenuManager.cpp
+++ b/src/core/GameMenuManager.cpp
@@ -129,6 +129,8 @@ void GameMenuManager::Initialize() {
 	TheGameMenuManager->Keys[209] = "PgDown";
 	TheGameMenuManager->Keys[210] = "Insert";
 	TheGameMenuManager->Keys[211] = "Delete";
+
+	TheGameMenuManager->IsLiveMenu = nullptr;
 }
 
 void GameMenuManager::UpdateSettings() {

--- a/src/core/GameMenuManager.h
+++ b/src/core/GameMenuManager.h
@@ -45,6 +45,14 @@ public:
 	std::chrono::system_clock::time_point		lastKeyPressed;
 	UInt16										keyDown;
 
+	enum MenuPauseState : uint32_t {
+		MENU_PAUSED	= 0, // Pauses the game, runs MenuMode only
+		MENU_LIVE	= 1, // Does not pause the game, runs both GameMode and MenuMode
+		MENU_MIXED	= 2, // Does not pause the game, runs only MenuMode
+	};
+
+	MenuPauseState(__cdecl* IsLiveMenu)(uint32_t aeMenu, bool abCheckInstances, bool abGameModeCheck);
+
 	int HeaderYPos;
 	int MenuHeight;
 	int rowHeight;

--- a/src/core/ShaderManager.cpp
+++ b/src/core/ShaderManager.cpp
@@ -215,10 +215,16 @@ void ShaderManager::UpdateConstants() {
 	if (Effects.Debug->Enabled) avglumaRequired = true;
 
 	// context variables
-	GameState.PipBoyIsOn = InterfaceManager->getIsMenuOpen();
+	GameState.PipBoyIsOn = InterfaceManager->IsPipBoyOpen();
 	GameState.VATSIsOn = InterfaceManager->IsActive(Menu::kMenuType_VATS);
-	GameState.OverlayIsOn = InterfaceManager->IsActive(Menu::kMenuType_Computers) ||
-		InterfaceManager->IsActive(Menu::kMenuType_LockPick) ||
+
+	const bool bHasRTM = TheGameMenuManager->IsLiveMenu != nullptr;
+	bool bComputersMenu = InterfaceManager->IsActive(Menu::kMenuType_Computers) && (bHasRTM ? (TheGameMenuManager->IsLiveMenu(Menu::kMenuType_Computers, false, false) == GameMenuManager::MENU_PAUSED) : true);
+	if (!bComputersMenu)
+		bComputersMenu = InterfaceManager->IsActive(Menu::kMenuType_Hacking) && (bHasRTM ? (TheGameMenuManager->IsLiveMenu(Menu::kMenuType_Hacking, false, false) == GameMenuManager::MENU_PAUSED) : true);
+	bool bLockpickMenu = LockPickMenu::GetSingleton() && (bHasRTM ? (TheGameMenuManager->IsLiveMenu(Menu::kMenuType_LockPick, false, false) == GameMenuManager::MENU_PAUSED) : true);
+
+	GameState.OverlayIsOn = bComputersMenu || bLockpickMenu ||
 		InterfaceManager->IsActive(Menu::kMenuType_Surgery) ||
 		InterfaceManager->IsActive(Menu::kMenuType_SlotMachine) ||
 		InterfaceManager->IsActive(Menu::kMenuType_Blackjack) ||

--- a/src/core/ShaderManager.cpp
+++ b/src/core/ShaderManager.cpp
@@ -692,7 +692,7 @@ void ShaderManager::RenderEffectToRT(IDirect3DSurface9* RenderTarget, EffectReco
 void ShaderManager::RenderEffectsPreTonemapping(IDirect3DSurface9* RenderTarget) {
 	if (!TheSettingManager->SettingsMain.Main.RenderEffects) return; // Main toggle
 	if (!Player->parentCell) return;
-	if (GameState.OverlayIsOn) return; // disable all effects during terminal/lockpicking sequences because they bleed through the overlay
+	if (GameState.OverlayIsOn && TESMain::IsMenuBackgroundReady()) return; // disable all effects during terminal/lockpicking sequences
 
 	auto timer = TimeLogger();
 


### PR DESCRIPTION
Adds compatibility with Real Time Menus, and fixes some bugs caused by shadow hooks:
- Original hook was skipping UI updates, as the function is not a dedicated shadow update function, but a more generic offscreen buffers update func 
- AddCastShadowFlagHook conflicts with JIP's light changes and messes JIP's internal state tracking (JIP reuses NiDynamicEffect's members)
- Shadows now render for static backgrounds (example: LockPickMenu)