### PR TITLE
Claude/plan imgui integration i4 xaz

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = lib/toml11
 	url = https://github.com/ToruNiina/toml11.git
 	ignore = dirty
+[submodule "lib/imgui"]
+	path = lib/imgui
+	url = https://github.com/ocornut/imgui.git
+	branch = docking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# TESReloaded10 — Dev Notes for Claude
+
+## Project
+New Vegas Reloaded (NVR) — a post-process graphics injector for Fallout: New Vegas.
+Built as a 32-bit DLL (NewVegasReloaded.vcxproj), injected via xNVSE.
+
+## Key architecture
+- `src/core/ImGuiManager.cpp` — ImGui settings overlay (DX9 + Win32 backend)
+- `src/core/ShaderManager.cpp` — main render loop; calls `ImGuiManager::NewFrame()` and `Render()`
+- `src/core/SettingManager.cpp` — TOML-backed settings; ImGui menu is auto-populated from this
+- `lib/imgui` — git submodule, docking branch (`git submodule update --init --recursive` required after fresh clone)
+- xNVSE headers live under `src/NewVegas/nvse/`
+
+## DXVK input — critical finding
+FNV is commonly run under **DXVK** (Vulkan translation layer). DXVK suppresses
+`WM_KEYDOWN` and `WM_MOUSEWHEEL` before they reach any subclassed WndProc.
+**Do not rely on WM messages for keyboard or scroll wheel input.**
+
+### What works instead
+| Input | Solution |
+|---|---|
+| Keyboard characters | `GetAsyncKeyState` poll each frame → `ToUnicode` → `io.AddInputCharacterUTF16` |
+| Keyboard nav keys (arrows, backspace, etc.) | `GetAsyncKeyState` poll → `io.AddKeyEvent(ImGuiKey_X, state)` |
+| Scroll wheel | Read `DIMOUSESTATE2::lZ` from the DI mouse buffer *before* zeroing it in `HookedGetDeviceState`, accumulate in `s_pendingWheelDelta`, inject via `io.AddMouseWheelEvent` in `NewFrame` |
+| Mouse buttons | `GetAsyncKeyState(VK_LBUTTON/RBUTTON/MBUTTON)` → `io.AddMouseButtonEvent` each frame |
+| Toggle key open/close | `OnKeyDown(KeyEnable)` reads raw DI `CurrentKeyState` buffer — not affected by our zeroing because we preserve that one byte |
+
+### What does NOT work under DXVK
+- `ImGui_ImplWin32_WndProcHandler` for keyboard/scroll (WM messages never arrive)
+- `WM_KEYDOWN` + `ToUnicode` in WndProc
+- Any WM_MOUSEWHEEL handler in WndProc
+
+WM_ACTIVATE and other non-input system messages still arrive normally.
+
+## Input blocking when overlay is open
+- **Mouse movement**: vtable hook on `IDirectInputDevice8::GetDeviceState` (slot 9), zeros `DIMOUSESTATE2` buffer. Keyboard device shares the same vtable in dinput8.dll so one patch covers both.
+- **Keyboard actions**: same hook zeros the 256-byte keyboard buffer (except toggle key byte).
+- **Mouse buttons / wheel macros**: `DIHookControl::SetKeyDisableState` via xNVSE for codes 0–265.
+
+## xNVSE
+Always check xNVSE (`src/NewVegas/nvse/`) before writing custom hooks for anything that interacts directly with the game (input, UI, game objects). Prefer xNVSE APIs over vtable patches where available.

--- a/NewVegasReloaded/Main.cpp
+++ b/NewVegasReloaded/Main.cpp
@@ -3,6 +3,7 @@
 
 #include "../src/NewVegas/Hooks/Hooks.h"
 #include "../src/core/Device/Hook.h"
+#include "../src/NewVegas/Managers.h"
 
 extern "C" {
 
@@ -100,7 +101,13 @@ extern "C" {
 		if (!Interface->IsEditor) {
 			((NVSEMessagingInterface*)Interface->QueryInterface(kInterface_Messaging))->RegisterListener(Interface->GetPluginHandle(), "NVSE", MessageHandler);
 			((NVSEMessagingInterface*)Interface->QueryInterface(kInterface_Messaging))->RegisterListener(Interface->GetPluginHandle(), "Shader Loader", ShaderLoaderHandler);
-			
+
+			auto* nvseData = (NVSEDataInterface*)Interface->QueryInterface(kInterface_Data);
+			if (nvseData)
+				g_DIHookCtrl = (DIHookControl*)nvseData->GetSingleton(NVSEDataInterface::kNVSEData_DIHookControl);
+
+			g_PlayerControls = (NVSETogglePlayerControlsInterface*)Interface->QueryInterface(kInterface_PlayerControls);
+
 			SettingManager::Initialize();
 			TheSettingManager->LoadSettings();
 			AttachHooks();

--- a/NewVegasReloaded/NewVegasReloaded.rc
+++ b/NewVegasReloaded/NewVegasReloaded.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,3,1,0
- PRODUCTVERSION 4,3,1,0
+ FILEVERSION 4,4,0,1
+ PRODUCTVERSION 4,4,0,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "New Vegas Reloaded"
-            VALUE "FileVersion", "4.4.0"
+            VALUE "FileVersion", "4.4.0a"
             VALUE "InternalName", "NewVegasReloaded.dll"
             VALUE "LegalCopyright", "Copyright (C) 2025"
             VALUE "OriginalFilename", "NewVegasReloaded.dll"
             VALUE "ProductName", "New Vegas Reloaded"
-            VALUE "ProductVersion", "4.4.0"
+            VALUE "ProductVersion", "4.4.0a (Unofficial)"
         END
     END
     BLOCK "VarFileInfo"

--- a/NewVegasReloaded/NewVegasReloaded.vcxproj
+++ b/NewVegasReloaded/NewVegasReloaded.vcxproj
@@ -180,6 +180,9 @@
     <ClCompile Include="..\lib\imgui\imgui.cpp">
       <ForcedIncludeFiles></ForcedIncludeFiles>
     </ClCompile>
+    <ClCompile Include="..\lib\imgui\imgui_demo.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
     <ClCompile Include="..\lib\imgui\imgui_draw.cpp">
       <ForcedIncludeFiles></ForcedIncludeFiles>
     </ClCompile>

--- a/NewVegasReloaded/NewVegasReloaded.vcxproj
+++ b/NewVegasReloaded/NewVegasReloaded.vcxproj
@@ -66,7 +66,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\Core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\Core;$(SolutionDir)lib\imgui;$(SolutionDir)lib\imgui\backends;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>$(SolutionDir)\src\NewVegas\Framework.h</ForcedIncludeFiles>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -92,7 +92,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;NEWVEGAS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\Core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\Core;$(SolutionDir)lib\imgui;$(SolutionDir)lib\imgui\backends;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>$(SolutionDir)\src\NewVegas\Framework.h</ForcedIncludeFiles>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -176,6 +176,24 @@
     <ClCompile Include="..\lib\Detours\detours.cpp" />
     <ClCompile Include="..\lib\Detours\disasm.cpp" />
     <ClCompile Include="..\lib\Detours\modules.cpp" />
+    <ClCompile Include="..\lib\imgui\imgui.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="..\lib\imgui\imgui_draw.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="..\lib\imgui\imgui_tables.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="..\lib\imgui\imgui_widgets.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="..\lib\imgui\backends\imgui_impl_dx9.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="..\lib\imgui\backends\imgui_impl_win32.cpp">
+      <ForcedIncludeFiles></ForcedIncludeFiles>
+    </ClCompile>
     <ClCompile Include="..\src\NewVegas\Hooks\FlyCam.cpp" />
     <ClCompile Include="..\src\NewVegas\Hooks\Game.cpp" />
     <ClCompile Include="..\src\NewVegas\Hooks\Hooks.cpp" />
@@ -257,6 +275,10 @@
     <ClInclude Include="..\lib\Bink\radbase.h" />
     <ClInclude Include="..\lib\Detours\detours.h" />
     <ClInclude Include="..\lib\Nvidia\nvapi.h" />
+    <ClInclude Include="..\lib\imgui\imgui.h" />
+    <ClInclude Include="..\lib\imgui\imgui_internal.h" />
+    <ClInclude Include="..\lib\imgui\backends\imgui_impl_dx9.h" />
+    <ClInclude Include="..\lib\imgui\backends\imgui_impl_win32.h" />
     <ClInclude Include="..\src\NewVegas\Base.h" />
     <ClInclude Include="..\src\NewVegas\Defines.h" />
     <ClInclude Include="..\src\NewVegas\Framework.h" />

--- a/NewVegasReloaded/NewVegasReloaded.vcxproj
+++ b/NewVegasReloaded/NewVegasReloaded.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="..\src\core\FrameRateManager.cpp" />
     <ClCompile Include="..\src\core\GameEventManager.cpp" />
     <ClCompile Include="..\src\core\GameMenuManager.cpp" />
+    <ClCompile Include="..\src\core\ImGuiManager.cpp" />
     <ClCompile Include="..\src\core\Hooks\FormsCommon.cpp" />
     <ClCompile Include="..\src\core\Hooks\GameCommon.cpp" />
     <ClCompile Include="..\src\core\RenderManager.cpp" />
@@ -217,6 +218,7 @@
     <ClInclude Include="..\src\core\FrameRateManager.h" />
     <ClInclude Include="..\src\core\GameEventManager.h" />
     <ClInclude Include="..\src\core\GameMenuManager.h" />
+    <ClInclude Include="..\src\core\ImGuiManager.h" />
     <ClInclude Include="..\src\core\Hooks\FormsCommon.h" />
     <ClInclude Include="..\src\core\Hooks\GameCommon.h" />
     <ClInclude Include="..\src\core\RenderManager.h" />

--- a/TESReloaded.sln
+++ b/TESReloaded.sln
@@ -1,10 +1,8 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.32106.194
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OblivionReloaded", "OblivionReloaded\OblivionReloaded.vcxproj", "{69334116-97D0-4670-89CB-4CC3216EB069}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NewVegasReloaded", "NewVegasReloaded\NewVegasReloaded.vcxproj", "{202EAF20-2D42-4CBC-9E44-A9677A70B586}"
 EndProject
 Global
@@ -13,10 +11,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{69334116-97D0-4670-89CB-4CC3216EB069}.Debug|x86.ActiveCfg = Debug|Win32
-		{69334116-97D0-4670-89CB-4CC3216EB069}.Debug|x86.Build.0 = Debug|Win32
-		{69334116-97D0-4670-89CB-4CC3216EB069}.Release|x86.ActiveCfg = Release|Win32
-		{69334116-97D0-4670-89CB-4CC3216EB069}.Release|x86.Build.0 = Release|Win32
 		{202EAF20-2D42-4CBC-9E44-A9677A70B586}.Debug|x86.ActiveCfg = Debug|Win32
 		{202EAF20-2D42-4CBC-9E44-A9677A70B586}.Debug|x86.Build.0 = Debug|Win32
 		{202EAF20-2D42-4CBC-9E44-A9677A70B586}.Release|x86.ActiveCfg = Release|Win32

--- a/src/NewVegas/Hooks/Render.cpp
+++ b/src/NewVegas/Hooks/Render.cpp
@@ -239,10 +239,6 @@ __declspec(naked) void RenderInterfaceHook() {
 		popad
 		call	Jumpers::RenderInterface::Method
 		pushad
-		mov		ecx, TheGameMenuManager
-		call	GameMenuManager::Render
-		popad
-		pushad
 		call	CallImGuiRender
 		popad
 		jmp		Jumpers::RenderInterface::Return

--- a/src/NewVegas/Hooks/Render.cpp
+++ b/src/NewVegas/Hooks/Render.cpp
@@ -216,7 +216,7 @@ void __cdecl ProcessImageSpaceShadersHook(NiDX9Renderer* Renderer, BSRenderedTex
 	if (GameSurface) GameSurface->Release();
 }
 
-static void RenderMainMenuMovie() { 
+static void RenderMainMenuMovie() {
 
 	if (TheSettingManager->SettingsMain.Main.ReplaceIntro && InterfaceManager->IsActive(Menu::MenuType::kMenuType_Main))
 		TheBinkManager->Render(MainMenuMovie);
@@ -225,16 +225,25 @@ static void RenderMainMenuMovie() {
 
 }
 
+static void CallImGuiNewFrame() { ImGuiManager::NewFrame(); }
+static void CallImGuiRender()   { ImGuiManager::Render(); }
+
 __declspec(naked) void RenderInterfaceHook() {
 
 	__asm {
 		pushad
 		call	RenderMainMenuMovie
 		popad
+		pushad
+		call	CallImGuiNewFrame
+		popad
 		call	Jumpers::RenderInterface::Method
 		pushad
 		mov		ecx, TheGameMenuManager
 		call	GameMenuManager::Render
+		popad
+		pushad
+		call	CallImGuiRender
 		popad
 		jmp		Jumpers::RenderInterface::Return
 	}

--- a/src/NewVegas/Managers.cpp
+++ b/src/NewVegas/Managers.cpp
@@ -1,3 +1,6 @@
+DIHookControl*                       g_DIHookCtrl     = NULL;
+NVSETogglePlayerControlsInterface*   g_PlayerControls = NULL;
+
 CommandManager*		TheCommandManager	= NULL;
 SettingManager*		TheSettingManager	= NULL;
 ShaderManager*		TheShaderManager	= NULL;

--- a/src/NewVegas/Managers.h
+++ b/src/NewVegas/Managers.h
@@ -30,6 +30,7 @@ class ShadowSceneNode;		extern ShadowSceneNode*			SceneNode;
 #include "../Core/FrameRateManager.h"
 #include "../Core/GameEventManager.h"
 #include "../Core/GameMenuManager.h"
+#include "../Core/ImGuiManager.h"
 #include "../Core/RenderPass.h"
 #include "../Core/ShadowManager.h"
 #include "../Core/CameraManager.h"

--- a/src/NewVegas/Managers.h
+++ b/src/NewVegas/Managers.h
@@ -12,6 +12,9 @@ class ShadowManager;	extern ShadowManager*		TheShadowManager;
 class CameraManager;	extern CameraManager*		TheCameraManager;
 class BinkManager;		extern BinkManager*			TheBinkManager;
 
+class DIHookControl;                         extern DIHookControl*                        g_DIHookCtrl;
+struct NVSETogglePlayerControlsInterface;    extern NVSETogglePlayerControlsInterface*     g_PlayerControls;
+
 class Main;					extern Main*					Global;
 class TES;					extern TES*						Tes;
 class PlayerCharacter;		extern PlayerCharacter*			Player;
@@ -31,6 +34,7 @@ class ShadowSceneNode;		extern ShadowSceneNode*			SceneNode;
 #include "../Core/GameEventManager.h"
 #include "../Core/GameMenuManager.h"
 #include "../Core/ImGuiManager.h"
+#include "nvse/DIHookControl.h"
 #include "../Core/RenderPass.h"
 #include "../Core/ShadowManager.h"
 #include "../Core/CameraManager.h"

--- a/src/NewVegas/Plugin.h
+++ b/src/NewVegas/Plugin.h
@@ -80,6 +80,7 @@ enum
 	// Added v0006
 	kInterface_EventManager,
 	kInterface_Logging,
+	kInterface_PlayerControls,
 
 	kInterface_Max
 };
@@ -163,4 +164,66 @@ struct NVSEMessagingInterface
 	UInt32	version;
 	bool	(* RegisterListener)(PluginHandle listener, const char* sender, EventCallback handler);
 	bool	(* Dispatch)(PluginHandle sender, UInt32 messageType, void * data, UInt32 dataLen, const char* receiver);
+};
+
+struct NVSEDataInterface
+{
+	enum { kVersion = 3 };
+	UInt32 version;
+
+	enum
+	{
+		kNVSEData_DIHookControl = 1,
+		kNVSEData_ArrayMap,
+		kNVSEData_StringMap,
+		kNVSEData_InventoryReferenceMap,
+		kNVSEData_SingletonMax,
+	};
+	void* (*GetSingleton)(UInt32 singletonID);
+
+	enum
+	{
+		kNVSEData_InventoryReferenceCreate = 1,
+		kNVSEData_FuncMax,
+	};
+	void* (*GetFunc)(UInt32 funcID);
+	void* (*GetData)(UInt32 dataID);
+	void  (*ClearScriptDataCache)();
+};
+
+namespace TogglePlayerControlsAlt
+{
+	enum DisabledControlsFlags : UInt32
+	{
+		kFlag_Movement          = 1 << 0,
+		kFlag_Looking           = 1 << 1,
+		kFlag_Pipboy            = 1 << 2,
+		kFlag_Fighting          = 1 << 3,
+		kFlag_POV               = 1 << 4,
+		kFlag_RolloverText      = 1 << 5,
+		kFlag_Sneaking          = 1 << 6,
+		kFlag_Attacking         = 1 << 7,
+		kFlag_EnterVATS         = 1 << 8,
+		kFlag_Jumping           = 1 << 9,
+		kFlag_AimingOrBlocking  = 1 << 10,
+		kFlag_Running           = 1 << 11,
+	};
+
+	enum CheckDisabledHow : UInt8
+	{
+		ByCallingMod = 0,
+		ByAnyMod,
+		ByAnyModOrVanilla,
+		ByVanillaOnly,
+	};
+}
+
+struct NVSETogglePlayerControlsInterface
+{
+	void   (__fastcall* DisablePlayerControlsAlt)(UInt32 flagsToAdd, const char* modName);
+	void   (__fastcall* EnablePlayerControlsAlt)(UInt32 flagsToRemove, const char* modName);
+	bool   (__cdecl*    GetPlayerControlsDisabledAlt)(TogglePlayerControlsAlt::CheckDisabledHow how,
+	                                                   UInt32 flagsToCheck, const char* modName);
+	UInt32 (__fastcall* GetDisabledPlayerControls)(TogglePlayerControlsAlt::CheckDisabledHow how,
+	                                               const char* modName);
 };

--- a/src/NewVegas/nvse/DIHookControl.h
+++ b/src/NewVegas/nvse/DIHookControl.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// Minimal mirror of xNVSE's DIHookControl for use by plugins.
+//
+// DIHookControl inherits from ISingleton<DIHookControl>, which has a virtual
+// destructor.  That adds a vtable pointer at offset 0 in every instance, so
+// m_keys begins at offset 4.  We replicate that layout here by declaring our
+// own virtual destructor so the compiler inserts the same vtable slot.
+//
+// Obtain the singleton pointer via:
+//   auto* data = (NVSEDataInterface*)nvse->QueryInterface(kInterface_Data);
+//   g_DIHookCtrl = (DIHookControl*)data->GetSingleton(NVSEDataInterface::kNVSEData_DIHookControl);
+
+enum
+{
+    kMacro_MouseButtonOffset = 256,         // LMB=256, RMB=257, ...
+    kMacro_MouseWheelOffset  = 256 + 8,     // wheel-up=264, wheel-down=265
+    kMaxMacros               = 256 + 8 + 2, // 266 total
+};
+
+class DIHookControl
+{
+public:
+    virtual ~DIHookControl() = default; // mirrors ISingleton virtual dtor; keeps vtable ptr in layout
+
+    enum
+    {
+        kDisable_User   = 1 << 0,
+        kDisable_Script = 1 << 1,
+        kDisable_All    = kDisable_User | kDisable_Script,
+    };
+
+    void SetKeyDisableState(UInt32 keycode, bool bDisable, UInt32 mask = 0)
+    {
+        if (!mask) mask = kDisable_All;
+        if (keycode >= kMaxMacros) return;
+        if (mask & kDisable_User)   m_keys[keycode].userDisable   = bDisable;
+        if (mask & kDisable_Script) m_keys[keycode].scriptDisable = bDisable;
+    }
+
+private:
+    // Must exactly match xNVSE's KeyInfo layout (7 bools, no padding).
+    struct KeyInfo
+    {
+        bool rawState, gameState, insertedState, hold, tap, userDisable, scriptDisable;
+    };
+    KeyInfo m_keys[kMaxMacros]; // offset 4 (after vtable ptr)
+};

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -58,7 +58,9 @@ static void PatchMouseVTable() {
 
 static void BlockGameInput(bool block) {
 	if (g_DIHookCtrl) {
-		for (UInt32 code = kMacro_MouseButtonOffset; code < kMaxMacros; code++)
+		// Block keyboard (0-255) and mouse buttons/wheel (256+) so the game
+		// doesn't process input while the overlay is open.
+		for (UInt32 code = 0; code < kMaxMacros; code++)
 			g_DIHookCtrl->SetKeyDisableState(code, block, DIHookControl::kDisable_User);
 	}
 }

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -4,7 +4,6 @@
 #include "imgui_impl_win32.h"
 #include <sstream>
 #include <iomanip>
-#include <unordered_map>
 #include <commdlg.h>
 #pragma comment(lib, "comdlg32.lib")
 
@@ -85,6 +84,19 @@ static void SetOverlayVisible(bool visible) {
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE && !InFileDialog)
 		SetOverlayVisible(false);
+
+	// Toggle key handled via WM so it works regardless of DirectInput state.
+	// Reconstruct the DIK code from the scan code + extended flag, then compare
+	// with the configured KeyEnable value.
+	if (msg == WM_KEYDOWN && TheSettingManager) {
+		UINT scancode = (lParam >> 16) & 0xFF;
+		bool ext      = (lParam & (1 << 24)) != 0;
+		UINT dik      = ext ? (0x80 | scancode) : scancode;
+		if (dik == TheSettingManager->SettingsMain.Menu.KeyEnable) {
+			SetOverlayVisible(!Visible);
+			return TRUE;
+		}
+	}
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
 	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
@@ -176,10 +188,6 @@ void ImGuiManager::NewFrame() {
 	if (Visible && !InterfaceManager->IsActive(Menu::MenuType::kMenuType_None))
 		SetOverlayVisible(false);
 
-	// Toggle via the configured key (same DirectInput keycode the old menu used)
-	if (TheSettingManager && Global && Global->OnKeyDown(TheSettingManager->SettingsMain.Menu.KeyEnable))
-		SetOverlayVisible(!Visible);
-
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();
@@ -233,18 +241,21 @@ static void RenderSetting(SettingManager::Configuration::ConfigNode& node) {
 		break;
 	}
 	default: {
-		// A plain local buf reset from node.Value each frame causes ImGui to detect
-		// an external buffer change and reset the in-progress edit every frame.
-		// Use a persistent buffer per widget ID, only refreshed when not editing.
-		static std::unordered_map<ImGuiID, std::array<char, 80>> sBufs;
+		// A local buf reset from node.Value each frame causes ImGui to detect an
+		// external buffer change and reset the in-progress edit every frame.
+		// Persist a string per widget ID; only refresh from node.Value when idle.
+		static std::unordered_map<ImGuiID, std::string> sBufs;
 		ImGuiID id = ImGui::GetID(node.Key);
-		auto& buf = sBufs[id];
+		std::string& persistent = sBufs[id];
 		if (ImGui::GetActiveID() != id)
-			strncpy_s(buf.data(), buf.size(), node.Value, _TRUNCATE);
-		if (ImGui::InputText(node.Key, buf.data(), buf.size()))
-			; // ImGui writes back to buf each frame while active; commit on focus loss
+			persistent = node.Value;
+		char buf[80];
+		strncpy_s(buf, persistent.c_str(), sizeof(buf) - 1);
+		buf[sizeof(buf) - 1] = '\0';
+		if (ImGui::InputText(node.Key, buf, sizeof(buf)))
+			persistent = buf; // keep in sync while ImGui writes back each frame
 		if (ImGui::IsItemDeactivatedAfterEdit()) {
-			TheSettingManager->SetSettingS(node.Section, node.Key, buf.data());
+			TheSettingManager->SetSettingS(node.Section, node.Key, buf);
 			TheSettingManager->LoadSettings();
 		}
 		break;

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -9,9 +9,6 @@
 
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-typedef HRESULT(WINAPI* GetDeviceState_t)(IDirectInputDevice8*, DWORD, LPVOID);
-static GetDeviceState_t OriginalGetDeviceState = nullptr;
-
 bool    ImGuiManager::Initialized     = false;
 bool    ImGuiManager::Visible         = false;
 bool    ImGuiManager::DeviceLost      = false;
@@ -23,40 +20,35 @@ static std::string SelectedSection;
 static std::string HoveredDescription;
 static bool        InFileDialog       = false;
 
-// ---- DirectInput mouse block --------------------------------------------------
+// Flags we disable on the player while the overlay is open.
+static constexpr UInt32 kOverlayControlFlags =
+	TogglePlayerControlsAlt::kFlag_Movement   |
+	TogglePlayerControlsAlt::kFlag_Looking    |
+	TogglePlayerControlsAlt::kFlag_Fighting   |
+	TogglePlayerControlsAlt::kFlag_Attacking  |
+	TogglePlayerControlsAlt::kFlag_AimingOrBlocking |
+	TogglePlayerControlsAlt::kFlag_EnterVATS  |
+	TogglePlayerControlsAlt::kFlag_Jumping    |
+	TogglePlayerControlsAlt::kFlag_POV;
 
-static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
-	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
-	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
-		memset(lpvData, 0, cbData);
-	return hr;
-}
+// ---- xNVSE input block -------------------------------------------------------
 
-static void** GetMouseVTable() {
-	InputControl* input = Global->GetInputControl();
-	if (!input || !input->mouseInterface) return nullptr;
-	return *reinterpret_cast<void***>(input->mouseInterface);
-}
+static void BlockGameInput(bool block) {
+	// Block/unblock all mouse buttons and wheel via DIHookControl so clicks and
+	// scroll events don't reach the game while the overlay is open.
+	if (g_DIHookCtrl) {
+		for (UInt32 code = kMacro_MouseButtonOffset; code < kMaxMacros; code++)
+			g_DIHookCtrl->SetKeyDisableState(code, block, DIHookControl::kDisable_User);
+	}
 
-static void PatchMouseVTable() {
-	void** vtable = GetMouseVTable();
-	if (!vtable) return;
-	if (vtable[9] == reinterpret_cast<void*>(HookedGetDeviceState)) return;
-	OriginalGetDeviceState = reinterpret_cast<GetDeviceState_t>(vtable[9]);
-	DWORD old;
-	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &old);
-	vtable[9] = reinterpret_cast<void*>(HookedGetDeviceState);
-	VirtualProtect(&vtable[9], sizeof(void*), old, &old);
-}
-
-static void RestoreMouseVTable() {
-	if (!OriginalGetDeviceState) return;
-	void** vtable = GetMouseVTable();
-	if (!vtable) return;
-	DWORD old;
-	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &old);
-	vtable[9] = reinterpret_cast<void*>(OriginalGetDeviceState);
-	VirtualProtect(&vtable[9], sizeof(void*), old, &old);
+	// Disable/enable player controls (camera, movement, etc.) so the character
+	// doesn't react to mouse deltas or WASD while the overlay is open.
+	if (g_PlayerControls) {
+		if (block)
+			g_PlayerControls->DisablePlayerControlsAlt(kOverlayControlFlags, "NVR");
+		else
+			g_PlayerControls->EnablePlayerControlsAlt(kOverlayControlFlags, "NVR");
+	}
 }
 
 // ---- Cursor / visibility -----------------------------------------------------
@@ -65,15 +57,16 @@ static void SetOverlayVisible(bool visible) {
 	if (ImGuiManager::IsVisible() == visible) return;
 	ImGuiManager::SetVisible(visible);
 	if (visible) {
-		// ShowCursor uses a reference counter; we need to track every TRUE call
-		// so we can undo exactly that many FALSE calls on hide.
+		// ShowCursor uses a reference counter; track every TRUE call so we can
+		// undo exactly that many FALSE calls on hide.
 		CursorShowDelta = 0;
 		int count;
 		do { count = ShowCursor(TRUE); CursorShowDelta++; } while (count < 0);
 		ClipCursor(nullptr);
-		PatchMouseVTable();
+		BlockGameInput(true);
 		ImGui::GetIO().ClearInputKeys();
 	} else {
+		BlockGameInput(false);
 		for (int i = 0; i < CursorShowDelta; i++) ShowCursor(FALSE);
 		CursorShowDelta = 0;
 	}
@@ -138,7 +131,6 @@ void ImGuiManager::Initialize() {
 	ImGui_ImplDX9_Init(device);
 
 	OriginalWndProc = (WNDPROC)SetWindowLong(hwnd, GWL_WNDPROC, (LONG)(LONG_PTR)WndProc);
-	PatchMouseVTable();
 
 	Initialized = true;
 	Logger::Log("ImGuiManager: Initialized");
@@ -147,7 +139,6 @@ void ImGuiManager::Initialize() {
 void ImGuiManager::Shutdown() {
 	if (!Initialized) return;
 	SetOverlayVisible(false);
-	RestoreMouseVTable();
 	SetWindowLong(GameWindow, GWL_WNDPROC, (LONG)(LONG_PTR)OriginalWndProc);
 	ImGui_ImplDX9_Shutdown();
 	ImGui_ImplWin32_Shutdown();
@@ -169,7 +160,6 @@ void ImGuiManager::NewFrame() {
 	if (DeviceLost && coop == D3DERR_DEVICENOTRESET) {
 		ImGui_ImplDX9_CreateDeviceObjects();
 		DeviceLost = false;
-		PatchMouseVTable();
 	}
 
 	// Close if a game menu is active (inventory, pip-boy, etc.)

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -198,6 +198,16 @@ static void PollKeyboardForImGui() {
 	static bool prevState[256] = {};
 	ImGuiIO& io = ImGui::GetIO();
 
+	// Convert the DIK toggle key to a VK so we can skip it — it's for open/close
+	// only and should not also navigate ImGui widgets.
+	int toggleVK = 0;
+	if (TheSettingManager) {
+		BYTE dik = (BYTE)TheSettingManager->SettingsMain.Menu.KeyEnable;
+		bool ext  = (dik & 0x80) != 0;
+		UINT scan = ext ? ((dik & 0x7F) | 0x100) : dik;
+		toggleVK = (int)MapVirtualKey(scan, MAPVK_VSC_TO_VK_EX);
+	}
+
 	// Build keyboard state for ToUnicode using async values for modifiers.
 	BYTE ks[256] = {};
 	GetKeyboardState(ks);
@@ -210,6 +220,8 @@ static void PollKeyboardForImGui() {
 	for (int vk = 1; vk < 256; vk++) {
 		// Skip generic aliases — we handle left/right variants explicitly.
 		if (vk == VK_SHIFT || vk == VK_CONTROL || vk == VK_MENU) continue;
+		// Skip the overlay toggle key — handled by OnKeyDown, not ImGui nav.
+		if (toggleVK && vk == toggleVK) { prevState[vk] = (GetAsyncKeyState(vk) & 0x8000) != 0; continue; }
 
 		bool cur  = (GetAsyncKeyState(vk) & 0x8000) != 0;
 		bool prev = prevState[vk];

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -306,7 +306,9 @@ static void RenderSectionNode(const std::string& path, const std::string& name, 
 			}
 		}
 	} else {
-		open = ImGui::TreeNode(name.c_str());
+		open = ImGui::TreeNode(("##" + path).c_str());
+		ImGui::SameLine();
+		ImGui::TextUnformatted(name.c_str());
 	}
 
 	if (open) {

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -1,0 +1,110 @@
+#include "ImGuiManager.h"
+#include "imgui.h"
+#include "imgui_impl_dx9.h"
+#include "imgui_impl_win32.h"
+
+// Forward declaration from imgui_impl_win32 — not exposed in the public header
+extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+bool    ImGuiManager::Initialized     = false;
+bool    ImGuiManager::Visible         = false;
+bool    ImGuiManager::DeviceLost      = false;
+HWND    ImGuiManager::GameWindow      = nullptr;
+WNDPROC ImGuiManager::OriginalWndProc = nullptr;
+
+LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
+		return TRUE;
+	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
+}
+
+void ImGuiManager::Initialize() {
+	if (Initialized) return;
+
+	IDirect3DDevice9* device = TheRenderManager->device;
+	HWND hwnd = TheRenderManager->m_kWndFocus;
+
+	if (!device || !hwnd) {
+		Logger::Log("ImGuiManager: device or window not ready, deferring init");
+		return;
+	}
+
+	GameWindow = hwnd;
+
+	IMGUI_CHECKVERSION();
+	ImGui::CreateContext();
+
+	ImGuiIO& io = ImGui::GetIO();
+	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+	io.IniFilename = nullptr;
+
+	ImGui::StyleColorsDark();
+
+	ImGui_ImplWin32_Init(hwnd);
+	ImGui_ImplDX9_Init(device);
+
+	OriginalWndProc = (WNDPROC)SetWindowLong(hwnd, GWL_WNDPROC, (LONG)(LONG_PTR)WndProc);
+
+	Initialized = true;
+	Logger::Log("ImGuiManager: Initialized");
+}
+
+void ImGuiManager::NewFrame() {
+	if (!Initialized) {
+		Initialize();
+		if (!Initialized) return;
+	}
+
+	// Handle device lost/reset so we never submit draw calls with a dead device
+	HRESULT coop = TheRenderManager->device->TestCooperativeLevel();
+	if (coop == D3DERR_DEVICELOST) {
+		if (!DeviceLost) {
+			ImGui_ImplDX9_InvalidateDeviceObjects();
+			DeviceLost = true;
+		}
+		return;
+	}
+	if (DeviceLost && coop == D3DERR_DEVICENOTRESET) {
+		ImGui_ImplDX9_CreateDeviceObjects();
+		DeviceLost = false;
+	}
+
+	// F11 toggles the overlay as a placeholder; Step 6 replaces this
+	// with the configured activation key from SettingManager.
+	if (GetAsyncKeyState(VK_F11) & 1)
+		Visible = !Visible;
+
+	ImGui_ImplDX9_NewFrame();
+	ImGui_ImplWin32_NewFrame();
+	ImGui::NewFrame();
+}
+
+void ImGuiManager::Render() {
+	if (!Initialized || DeviceLost) return;
+
+	if (Visible)
+		BuildUI();
+
+	ImGui::EndFrame();
+	ImGui::Render();
+	ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+}
+
+void ImGuiManager::BuildUI() {
+	// Placeholder — replaced in Step 6 with the full NVR settings menu
+	ImGui::ShowDemoWindow();
+}
+
+void ImGuiManager::Shutdown() {
+	if (!Initialized) return;
+
+	SetWindowLong(GameWindow, GWL_WNDPROC, (LONG)(LONG_PTR)OriginalWndProc);
+
+	ImGui_ImplDX9_Shutdown();
+	ImGui_ImplWin32_Shutdown();
+	ImGui::DestroyContext();
+
+	Initialized = false;
+	Logger::Log("ImGuiManager: Shutdown");
+}

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -5,8 +5,7 @@
 #include "imgui_impl_win32.h"
 #include <sstream>
 #include <iomanip>
-#include <commdlg.h>
-#pragma comment(lib, "comdlg32.lib")
+#include <ctime>
 
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
@@ -20,7 +19,6 @@ HWND    ImGuiManager::GameWindow      = nullptr;
 WNDPROC ImGuiManager::OriginalWndProc = nullptr;
 
 static std::string SelectedSection;
-static bool        InFileDialog       = false;
 
 // ---- DirectInput mouse block (zeros lX/lY/lZ deltas + buttons) ---------------
 // xNVSE has no public API to block mouse movement deltas, so we patch the
@@ -97,7 +95,7 @@ static void SetOverlayVisible(bool visible) {
 // ---- WndProc -----------------------------------------------------------------
 
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE && !InFileDialog)
+	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE)
 		SetOverlayVisible(false);
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
@@ -522,9 +520,9 @@ void ImGuiManager::BuildUI() {
 		ImGui::TextDisabled("New Vegas Reloaded  %s", PluginVersion::VersionString);
 
 	{
-		const float btnRevert = 54.0f, btnSaveTo = 72.0f, btnSave = 54.0f;
+		const float btnRevert = 54.0f, btnCopy = 72.0f, btnSave = 54.0f;
 		const float spacing   = ImGui::GetStyle().ItemSpacing.x;
-		const float totalW    = btnRevert + btnSaveTo + btnSave + spacing * 2.0f;
+		const float totalW    = btnRevert + btnCopy + btnSave + spacing * 2.0f;
 		ImGui::SameLine(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - totalW);
 
 		if (ImGui::Button("Revert", ImVec2(btnRevert, 0.0f))) {
@@ -532,25 +530,52 @@ void ImGuiManager::BuildUI() {
 			SelectedSection.clear();
 		}
 		ImGui::SameLine();
-		if (ImGui::Button("Save to...", ImVec2(btnSaveTo, 0.0f))) {
-			char path[MAX_PATH] = "NewVegasReloaded.dll.toml";
-			OPENFILENAMEA ofn   = {};
-			ofn.lStructSize     = sizeof(ofn);
-			ofn.hwndOwner       = GameWindow;
-			ofn.lpstrFilter     = "TOML Files\0*.toml\0All Files\0*.*\0";
-			ofn.lpstrFile       = path;
-			ofn.nMaxFile        = MAX_PATH;
-			ofn.lpstrDefExt     = "toml";
-			ofn.Flags           = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
-			InFileDialog = true;
-			bool ok = GetSaveFileNameA(&ofn) != 0;
-			InFileDialog = false;
-			SetForegroundWindow(GameWindow);
-			ClipCursor(nullptr);
-			ImGui::GetIO().ClearInputKeys();
-			SetOverlayVisible(true);
-			if (ok)
-				TheSettingManager->SaveSettingsTo(path);
+		if (ImGui::Button("Save Copy", ImVec2(btnCopy, 0.0f))) {
+			// Build timestamped path next to the DLL, e.g.:
+			// NewVegasReloaded_20260519_2119_WastelandNV.dll.toml
+			char dllPath[MAX_PATH] = {};
+			HMODULE hMod = nullptr;
+			GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+				GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+				(LPCSTR)&ImGuiManager::Initialize, &hMod);
+			GetModuleFileNameA(hMod, dllPath, MAX_PATH);
+
+			// Strip ".dll" suffix to get base path
+			char* ext = strrchr(dllPath, '.');
+			if (ext) *ext = '\0';
+
+			// Timestamp
+			time_t now = time(nullptr);
+			tm lt = {};
+			localtime_s(&lt, &now);
+			char ts[32] = {};
+			strftime(ts, sizeof(ts), "%Y%m%d_%H%M", &lt);
+
+			// Location: worldspace for exterior, cell name for interior
+			std::string loc;
+			if (Player && Player->parentCell) {
+				const char* name = nullptr;
+				if (Player->parentCell->IsInterior()) {
+					name = Player->parentCell->GetEditorName();
+				} else {
+					TESWorldSpace* ws = Player->GetWorldSpace();
+					if (ws) name = ws->GetEditorName();
+				}
+				if (name && name[0]) {
+					// Sanitize: keep alphanumeric, replace the rest with '_'
+					for (const char* c = name; *c; c++)
+						loc += (isalnum((unsigned char)*c) ? *c : '_');
+				}
+			}
+
+			char savePath[MAX_PATH] = {};
+			if (loc.empty())
+				_snprintf_s(savePath, sizeof(savePath), "%s_%s.dll.toml", dllPath, ts);
+			else
+				_snprintf_s(savePath, sizeof(savePath), "%s_%s_%s.dll.toml", dllPath, ts, loc.c_str());
+
+			TheSettingManager->SaveSettingsTo(savePath);
+			InterfaceManager->ShowMessage("Settings copy saved.");
 		}
 		ImGui::SameLine();
 		if (ImGui::Button("Save", ImVec2(btnSave, 0.0f))) {

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -5,7 +5,6 @@
 
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-// Original GetDeviceState from the mouse DirectInput device vtable (index 9)
 typedef HRESULT(WINAPI* GetDeviceState_t)(IDirectInputDevice8*, DWORD, LPVOID);
 static GetDeviceState_t OriginalGetDeviceState = nullptr;
 
@@ -15,8 +14,9 @@ bool    ImGuiManager::DeviceLost      = false;
 HWND    ImGuiManager::GameWindow      = nullptr;
 WNDPROC ImGuiManager::OriginalWndProc = nullptr;
 
-// Intercepts the game's mouse DirectInput read. When the overlay is open,
-// zero the result so camera movement and button presses don't reach the game.
+// Tracks exactly how many ShowCursor(TRUE) calls we made so we can undo only those.
+static int CursorShowDelta = 0;
+
 static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
 	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
 	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
@@ -24,11 +24,19 @@ static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cb
 	return hr;
 }
 
-static void PatchMouseVTable() {
+static void** GetMouseVTable() {
 	InputControl* input = Global->GetInputControl();
-	if (!input || !input->mouseInterface) return;
+	if (!input || !input->mouseInterface) return nullptr;
+	return *reinterpret_cast<void***>(input->mouseInterface);
+}
 
-	void** vtable = *reinterpret_cast<void***>(input->mouseInterface);
+static void PatchMouseVTable() {
+	void** vtable = GetMouseVTable();
+	if (!vtable) return;
+
+	// Only patch if not already patched
+	if (vtable[9] == reinterpret_cast<void*>(HookedGetDeviceState)) return;
+
 	OriginalGetDeviceState = reinterpret_cast<GetDeviceState_t>(vtable[9]);
 
 	DWORD oldProtect;
@@ -40,10 +48,8 @@ static void PatchMouseVTable() {
 static void RestoreMouseVTable() {
 	if (!OriginalGetDeviceState) return;
 
-	InputControl* input = Global->GetInputControl();
-	if (!input || !input->mouseInterface) return;
-
-	void** vtable = *reinterpret_cast<void***>(input->mouseInterface);
+	void** vtable = GetMouseVTable();
+	if (!vtable) return;
 
 	DWORD oldProtect;
 	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &oldProtect);
@@ -55,10 +61,14 @@ static void SetOverlayVisible(bool visible) {
 	if (ImGuiManager::IsVisible() == visible) return;
 	ImGuiManager::SetVisible(visible);
 	if (visible) {
-		while (ShowCursor(TRUE) < 0) {}
+		CursorShowDelta = 0;
+		while (ShowCursor(TRUE) < 0)
+			CursorShowDelta++;
 		ClipCursor(nullptr);
 	} else {
-		while (ShowCursor(FALSE) >= 0) {}
+		for (int i = 0; i < CursorShowDelta; i++)
+			ShowCursor(FALSE);
+		CursorShowDelta = 0;
 	}
 }
 
@@ -122,6 +132,8 @@ void ImGuiManager::NewFrame() {
 	if (DeviceLost && coop == D3DERR_DEVICENOTRESET) {
 		ImGui_ImplDX9_CreateDeviceObjects();
 		DeviceLost = false;
+		// Re-patch in case DirectInput reinitialized its device during reset
+		PatchMouseVTable();
 	}
 
 	if (GetAsyncKeyState(VK_F11) & 1)
@@ -131,8 +143,6 @@ void ImGuiManager::NewFrame() {
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();
 
-	// WM_LBUTTONDOWN doesn't reliably reach WndProc in fullscreen/captured mode,
-	// so feed button state directly from the hardware key table instead.
 	if (Visible) {
 		ImGuiIO& io = ImGui::GetIO();
 		io.AddMouseButtonEvent(0, (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0);
@@ -153,7 +163,6 @@ void ImGuiManager::Render() {
 }
 
 void ImGuiManager::BuildUI() {
-	// Placeholder — replaced in Step 6 with the full NVR settings menu
 	ImGui::ShowDemoWindow();
 }
 

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -1,5 +1,6 @@
 #include "ImGuiManager.h"
 #include "imgui.h"
+#include "imgui_internal.h"
 #include "imgui_impl_dx9.h"
 #include "imgui_impl_win32.h"
 #include <sstream>

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -29,11 +29,12 @@ static bool        InFileDialog       = false;
 
 static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
 	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
-	// Only zero mouse-sized buffers (DIMOUSESTATE2 = 20 bytes).  The keyboard
-	// device shares this vtable in dinput8.dll and calls GetDeviceState(256, ...);
-	// passing that through unchanged keeps OnKeyDown/OnKeyPressed working.
-	if (SUCCEEDED(hr) && ImGuiManager::IsVisible() && cbData == sizeof(DIMOUSESTATE2))
-		memset(lpvData, 0, cbData);
+	// Zero both mouse (DIMOUSESTATE2 = 20 bytes) and keyboard (256 bytes) buffers
+	// when the overlay is open.  Toggle key is handled via WM_KEYDOWN so it works
+	// even with the keyboard buffer zeroed.
+	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
+		if (cbData == sizeof(DIMOUSESTATE2) || cbData == 256)
+			memset(lpvData, 0, cbData);
 	return hr;
 }
 
@@ -86,6 +87,18 @@ static void SetOverlayVisible(bool visible) {
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE && !InFileDialog)
 		SetOverlayVisible(false);
+
+	// Toggle key via WM — works even when DI keyboard buffer is zeroed.
+	// Reconstruct DIK from scan code + extended flag to match the stored KeyEnable value.
+	if (msg == WM_KEYDOWN && TheSettingManager) {
+		UINT scan = (lParam >> 16) & 0xFF;
+		bool ext  = (lParam & (1 << 24)) != 0;
+		UINT dik  = ext ? (0x80 | scan) : scan;
+		if (dik == TheSettingManager->SettingsMain.Menu.KeyEnable) {
+			SetOverlayVisible(!Visible);
+			return TRUE;
+		}
+	}
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
 	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
@@ -176,10 +189,6 @@ void ImGuiManager::NewFrame() {
 	// Close if a game menu is active (inventory, pip-boy, etc.)
 	if (Visible && !InterfaceManager->IsActive(Menu::MenuType::kMenuType_None))
 		SetOverlayVisible(false);
-
-	// Toggle via the configured key (same DirectInput keycode the old menu used)
-	if (TheSettingManager && Global && Global->OnKeyDown(TheSettingManager->SettingsMain.Menu.KeyEnable))
-		SetOverlayVisible(!Visible);
 
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -29,12 +29,19 @@ static bool        InFileDialog       = false;
 
 static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
 	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
-	// Zero both mouse (DIMOUSESTATE2 = 20 bytes) and keyboard (256 bytes) buffers
-	// when the overlay is open.  Toggle key is handled via WM_KEYDOWN so it works
-	// even with the keyboard buffer zeroed.
-	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
-		if (cbData == sizeof(DIMOUSESTATE2) || cbData == 256)
+	if (SUCCEEDED(hr) && ImGuiManager::IsVisible()) {
+		if (cbData == sizeof(DIMOUSESTATE2)) {
 			memset(lpvData, 0, cbData);
+		} else if (cbData == 256) {
+			// Zero all keyboard keys except the toggle key so OnKeyDown can still
+			// detect it to close the overlay, while movement/actions are blocked.
+			BYTE toggleKey = TheSettingManager
+				? (BYTE)TheSettingManager->SettingsMain.Menu.KeyEnable : 0;
+			BYTE toggleState = toggleKey ? ((BYTE*)lpvData)[toggleKey] : 0;
+			memset(lpvData, 0, cbData);
+			if (toggleKey) ((BYTE*)lpvData)[toggleKey] = toggleState;
+		}
+	}
 	return hr;
 }
 
@@ -87,18 +94,6 @@ static void SetOverlayVisible(bool visible) {
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE && !InFileDialog)
 		SetOverlayVisible(false);
-
-	// Toggle key via WM — works even when DI keyboard buffer is zeroed.
-	// Reconstruct DIK from scan code + extended flag to match the stored KeyEnable value.
-	if (msg == WM_KEYDOWN && TheSettingManager) {
-		UINT scan = (lParam >> 16) & 0xFF;
-		bool ext  = (lParam & (1 << 24)) != 0;
-		UINT dik  = ext ? (0x80 | scan) : scan;
-		if (dik == TheSettingManager->SettingsMain.Menu.KeyEnable) {
-			SetOverlayVisible(!Visible);
-			return TRUE;
-		}
-	}
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
 	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
@@ -189,6 +184,11 @@ void ImGuiManager::NewFrame() {
 	// Close if a game menu is active (inventory, pip-boy, etc.)
 	if (Visible && !InterfaceManager->IsActive(Menu::MenuType::kMenuType_None))
 		SetOverlayVisible(false);
+
+	// Toggle via DirectInput raw buffer — OnKeyDown reads CurrentKeyState which
+	// is the raw DI buffer, preserved for this key even when the rest is zeroed.
+	if (TheSettingManager && Global && Global->OnKeyDown(TheSettingManager->SettingsMain.Menu.KeyEnable))
+		SetOverlayVisible(!Visible);
 
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -483,6 +483,11 @@ void ImGuiManager::BuildUI() {
 
 	if (!Visible) return;
 
+	if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+		SetOverlayVisible(false);
+		return;
+	}
+
 	ImGui::SetNextWindowSize(ImVec2(960.0f, 620.0f), ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(500.0f, 300.0f), ImVec2(FLT_MAX, FLT_MAX));
 

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -124,6 +124,15 @@ void ImGuiManager::NewFrame() {
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();
 	ImGui::NewFrame();
+
+	// WM_LBUTTONDOWN doesn't reliably reach WndProc in fullscreen/captured mode,
+	// so feed button state directly from the hardware key table instead.
+	if (Visible) {
+		ImGuiIO& io = ImGui::GetIO();
+		io.AddMouseButtonEvent(0, (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0);
+		io.AddMouseButtonEvent(1, (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0);
+		io.AddMouseButtonEvent(2, (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0);
+	}
 }
 
 void ImGuiManager::Render() {

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -565,6 +565,13 @@ void ImGuiManager::BuildUI() {
 				sanitize(Player->parentCell->GetEditorName(), cellName);
 				if (!wsName.empty()) loc = wsName;
 				if (!cellName.empty()) loc += (loc.empty() ? "" : "_") + cellName;
+				// Append grid coords for exterior cells
+				TESObjectCELL::CellCoordinates* coords = Player->parentCell->coords;
+				if (coords) {
+					char grid[32] = {};
+					_snprintf_s(grid, sizeof(grid), "_%d_%d", coords->x, coords->y);
+					loc += grid;
+				}
 			}
 
 			char savePath[MAX_PATH] = {};

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -483,7 +483,11 @@ void ImGuiManager::BuildUI() {
 
 	if (!Visible) return;
 
-	if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+	// Wait for Escape release before closing so the game doesn't see it still held.
+	static bool escapePending = false;
+	if (ImGui::IsKeyPressed(ImGuiKey_Escape)) escapePending = true;
+	if (escapePending && !ImGui::IsKeyDown(ImGuiKey_Escape)) {
+		escapePending = false;
 		SetOverlayVisible(false);
 		return;
 	}

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -86,19 +86,6 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE && !InFileDialog)
 		SetOverlayVisible(false);
 
-	// Toggle key handled via WM so it works regardless of DirectInput state.
-	// Reconstruct the DIK code from the scan code + extended flag, then compare
-	// with the configured KeyEnable value.
-	if (msg == WM_KEYDOWN && TheSettingManager) {
-		UINT scancode = (lParam >> 16) & 0xFF;
-		bool ext      = (lParam & (1 << 24)) != 0;
-		UINT dik      = ext ? (0x80 | scancode) : scancode;
-		if (dik == TheSettingManager->SettingsMain.Menu.KeyEnable) {
-			SetOverlayVisible(!Visible);
-			return TRUE;
-		}
-	}
-
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
 	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
 	if (Visible && msg == WM_KEYDOWN && wParam == VK_ESCAPE) {
@@ -188,6 +175,10 @@ void ImGuiManager::NewFrame() {
 	// Close if a game menu is active (inventory, pip-boy, etc.)
 	if (Visible && !InterfaceManager->IsActive(Menu::MenuType::kMenuType_None))
 		SetOverlayVisible(false);
+
+	// Toggle via the configured key (same DirectInput keycode the old menu used)
+	if (TheSettingManager && Global && Global->OnKeyDown(TheSettingManager->SettingsMain.Menu.KeyEnable))
+		SetOverlayVisible(!Visible);
 
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -413,7 +413,7 @@ void ImGuiManager::BuildUI() {
 			ofn.lpstrFile       = path;
 			ofn.nMaxFile        = MAX_PATH;
 			ofn.lpstrDefExt     = "toml";
-			ofn.Flags           = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
+			ofn.Flags           = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
 			InFileDialog = true;
 			bool ok = GetSaveFileNameA(&ofn) != 0;
 			InFileDialog = false;

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -100,10 +100,10 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
 	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
-	if (Visible && msg == WM_KEYDOWN && wParam == VK_ESCAPE) {
-		SetOverlayVisible(false);
+	// Eat Escape WM so the game never sees it; actual close is handled in BuildUI
+	// via polling (waits for key release before unblocking DI).
+	if (Visible && msg == WM_KEYDOWN && wParam == VK_ESCAPE)
 		return TRUE;
-	}
 
 if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
 		return TRUE;
@@ -551,21 +551,20 @@ void ImGuiManager::BuildUI() {
 			char ts[32] = {};
 			strftime(ts, sizeof(ts), "%Y%m%d_%H%M", &lt);
 
-			// Location: worldspace for exterior, cell name for interior
+			// Location: always include worldspace + cell editor ID for TTW compatibility.
+			auto sanitize = [](const char* s, std::string& out) {
+				if (s && s[0])
+					for (const char* c = s; *c; c++)
+						out += (isalnum((unsigned char)*c) ? *c : '_');
+			};
 			std::string loc;
 			if (Player && Player->parentCell) {
-				const char* name = nullptr;
-				if (Player->parentCell->IsInterior()) {
-					name = Player->parentCell->GetEditorName();
-				} else {
-					TESWorldSpace* ws = Player->GetWorldSpace();
-					if (ws) name = ws->GetEditorName();
-				}
-				if (name && name[0]) {
-					// Sanitize: keep alphanumeric, replace the rest with '_'
-					for (const char* c = name; *c; c++)
-						loc += (isalnum((unsigned char)*c) ? *c : '_');
-				}
+				TESWorldSpace* ws = Player->GetWorldSpace();
+				std::string wsName, cellName;
+				if (ws) sanitize(ws->GetEditorName(), wsName);
+				sanitize(Player->parentCell->GetEditorName(), cellName);
+				if (!wsName.empty()) loc = wsName;
+				if (!cellName.empty()) loc += (loc.empty() ? "" : "_") + cellName;
 			}
 
 			char savePath[MAX_PATH] = {};

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -21,6 +21,7 @@ WNDPROC ImGuiManager::OriginalWndProc = nullptr;
 static int         CursorShowDelta    = 0;
 static std::string SelectedSection;
 static std::string HoveredDescription;
+static bool        InFileDialog       = false;
 
 // ---- DirectInput mouse block --------------------------------------------------
 
@@ -76,7 +77,7 @@ static void SetOverlayVisible(bool visible) {
 // ---- WndProc -----------------------------------------------------------------
 
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE)
+	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE && !InFileDialog)
 		SetOverlayVisible(false);
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
@@ -412,7 +413,11 @@ void ImGuiManager::BuildUI() {
 			ofn.nMaxFile        = MAX_PATH;
 			ofn.lpstrDefExt     = "toml";
 			ofn.Flags           = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
-			if (GetSaveFileNameA(&ofn))
+			InFileDialog = true;
+			bool ok = GetSaveFileNameA(&ofn) != 0;
+			InFileDialog = false;
+			SetOverlayVisible(true);
+			if (ok)
 				TheSettingManager->SaveSettingsTo(path);
 		}
 		ImGui::SameLine();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -2,6 +2,8 @@
 #include "imgui.h"
 #include "imgui_impl_dx9.h"
 #include "imgui_impl_win32.h"
+#include <sstream>
+#include <iomanip>
 
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
@@ -14,8 +16,11 @@ bool    ImGuiManager::DeviceLost      = false;
 HWND    ImGuiManager::GameWindow      = nullptr;
 WNDPROC ImGuiManager::OriginalWndProc = nullptr;
 
-// Tracks exactly how many ShowCursor(TRUE) calls we made so we can undo only those.
-static int CursorShowDelta = 0;
+static int         CursorShowDelta    = 0;
+static std::string SelectedSection;
+static std::string HoveredDescription;
+
+// ---- DirectInput mouse block --------------------------------------------------
 
 static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
 	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
@@ -33,64 +38,57 @@ static void** GetMouseVTable() {
 static void PatchMouseVTable() {
 	void** vtable = GetMouseVTable();
 	if (!vtable) return;
-
-	// Only patch if not already patched
 	if (vtable[9] == reinterpret_cast<void*>(HookedGetDeviceState)) return;
-
 	OriginalGetDeviceState = reinterpret_cast<GetDeviceState_t>(vtable[9]);
-
-	DWORD oldProtect;
-	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &oldProtect);
+	DWORD old;
+	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &old);
 	vtable[9] = reinterpret_cast<void*>(HookedGetDeviceState);
-	VirtualProtect(&vtable[9], sizeof(void*), oldProtect, &oldProtect);
+	VirtualProtect(&vtable[9], sizeof(void*), old, &old);
 }
 
 static void RestoreMouseVTable() {
 	if (!OriginalGetDeviceState) return;
-
 	void** vtable = GetMouseVTable();
 	if (!vtable) return;
-
-	DWORD oldProtect;
-	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &oldProtect);
+	DWORD old;
+	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &old);
 	vtable[9] = reinterpret_cast<void*>(OriginalGetDeviceState);
-	VirtualProtect(&vtable[9], sizeof(void*), oldProtect, &oldProtect);
+	VirtualProtect(&vtable[9], sizeof(void*), old, &old);
 }
+
+// ---- Cursor / visibility -----------------------------------------------------
 
 static void SetOverlayVisible(bool visible) {
 	if (ImGuiManager::IsVisible() == visible) return;
 	ImGuiManager::SetVisible(visible);
 	if (visible) {
 		CursorShowDelta = 0;
-		while (ShowCursor(TRUE) < 0)
-			CursorShowDelta++;
+		while (ShowCursor(TRUE) < 0) CursorShowDelta++;
 		ClipCursor(nullptr);
 	} else {
-		for (int i = 0; i < CursorShowDelta; i++)
-			ShowCursor(FALSE);
+		for (int i = 0; i < CursorShowDelta; i++) ShowCursor(FALSE);
 		CursorShowDelta = 0;
 	}
 }
 
+// ---- WndProc -----------------------------------------------------------------
+
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE)
 		SetOverlayVisible(false);
-
 	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
 		return TRUE;
 	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
 }
+
+// ---- Init / shutdown ---------------------------------------------------------
 
 void ImGuiManager::Initialize() {
 	if (Initialized) return;
 
 	IDirect3DDevice9* device = TheRenderManager->device;
 	HWND hwnd = TheRenderManager->m_kWndFocus;
-
-	if (!device || !hwnd) {
-		Logger::Log("ImGuiManager: device or window not ready, deferring init");
-		return;
-	}
+	if (!device || !hwnd) { Logger::Log("ImGuiManager: deferring init"); return; }
 
 	GameWindow = hwnd;
 
@@ -103,40 +101,54 @@ void ImGuiManager::Initialize() {
 	io.IniFilename = nullptr;
 
 	ImGui::StyleColorsDark();
+	ImGui::GetStyle().WindowRounding    = 6.0f;
+	ImGui::GetStyle().FrameRounding     = 3.0f;
+	ImGui::GetStyle().ScrollbarRounding = 3.0f;
 
 	ImGui_ImplWin32_Init(hwnd);
 	ImGui_ImplDX9_Init(device);
 
 	OriginalWndProc = (WNDPROC)SetWindowLong(hwnd, GWL_WNDPROC, (LONG)(LONG_PTR)WndProc);
-
 	PatchMouseVTable();
 
 	Initialized = true;
 	Logger::Log("ImGuiManager: Initialized");
 }
 
+void ImGuiManager::Shutdown() {
+	if (!Initialized) return;
+	SetOverlayVisible(false);
+	RestoreMouseVTable();
+	SetWindowLong(GameWindow, GWL_WNDPROC, (LONG)(LONG_PTR)OriginalWndProc);
+	ImGui_ImplDX9_Shutdown();
+	ImGui_ImplWin32_Shutdown();
+	ImGui::DestroyContext();
+	Initialized = false;
+	Logger::Log("ImGuiManager: Shutdown");
+}
+
+// ---- Frame -------------------------------------------------------------------
+
 void ImGuiManager::NewFrame() {
-	if (!Initialized) {
-		Initialize();
-		if (!Initialized) return;
-	}
+	if (!Initialized) { Initialize(); if (!Initialized) return; }
 
 	HRESULT coop = TheRenderManager->device->TestCooperativeLevel();
 	if (coop == D3DERR_DEVICELOST) {
-		if (!DeviceLost) {
-			ImGui_ImplDX9_InvalidateDeviceObjects();
-			DeviceLost = true;
-		}
+		if (!DeviceLost) { ImGui_ImplDX9_InvalidateDeviceObjects(); DeviceLost = true; }
 		return;
 	}
 	if (DeviceLost && coop == D3DERR_DEVICENOTRESET) {
 		ImGui_ImplDX9_CreateDeviceObjects();
 		DeviceLost = false;
-		// Re-patch in case DirectInput reinitialized its device during reset
 		PatchMouseVTable();
 	}
 
-	if (GetAsyncKeyState(VK_F11) & 1)
+	// Close if a game menu is active (inventory, pip-boy, etc.)
+	if (Visible && !InterfaceManager->IsActive(Menu::MenuType::kMenuType_None))
+		SetOverlayVisible(false);
+
+	// Toggle via the configured key (same DirectInput keycode the old menu used)
+	if (TheSettingManager && Global && Global->OnKeyDown(TheSettingManager->SettingsMain.Menu.KeyEnable))
 		SetOverlayVisible(!Visible);
 
 	ImGui_ImplDX9_NewFrame();
@@ -153,30 +165,235 @@ void ImGuiManager::NewFrame() {
 
 void ImGuiManager::Render() {
 	if (!Initialized || DeviceLost) return;
-
-	if (Visible)
-		BuildUI();
-
+	BuildUI();
 	ImGui::EndFrame();
 	ImGui::Render();
 	ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
 }
 
-void ImGuiManager::BuildUI() {
-	ImGui::ShowDemoWindow();
+// ---- Menu UI -----------------------------------------------------------------
+
+static void RenderSetting(SettingManager::Configuration::ConfigNode& node) {
+	using NodeType = SettingManager::Configuration::NodeType;
+
+	ImGui::PushID(node.Key);
+
+	switch (node.Type) {
+	case NodeType::Boolean: {
+		bool val = (strcmp(node.Value, "1") == 0 || _stricmp(node.Value, "true") == 0);
+		if (ImGui::Checkbox(node.Key, &val)) {
+			TheSettingManager->SetSetting(node.Section, node.Key, val);
+			TheSettingManager->LoadSettings();
+		}
+		break;
+	}
+	case NodeType::Float: {
+		float val = (float)atof(node.Value);
+		if (ImGui::DragFloat(node.Key, &val, 0.001f, 0.0f, 0.0f, "%.4f"))
+			if (ImGui::IsItemDeactivatedAfterEdit()) {
+				TheSettingManager->SetSetting(node.Section, node.Key, val);
+				TheSettingManager->LoadSettings();
+			}
+		break;
+	}
+	case NodeType::Integer: {
+		int val = atoi(node.Value);
+		if (ImGui::DragInt(node.Key, &val, 1.0f))
+			if (ImGui::IsItemDeactivatedAfterEdit()) {
+				TheSettingManager->SetSetting(node.Section, node.Key, val);
+				TheSettingManager->LoadSettings();
+			}
+		break;
+	}
+	default: {
+		char buf[80];
+		strncpy_s(buf, node.Value, sizeof(buf));
+		if (ImGui::InputText(node.Key, buf, sizeof(buf), ImGuiInputTextFlags_EnterReturnsTrue)) {
+			TheSettingManager->SetSettingS(node.Section, node.Key, buf);
+			TheSettingManager->LoadSettings();
+		}
+		break;
+	}
+	}
+
+	if (ImGui::IsItemHovered() && !node.Description.empty())
+		HoveredDescription = node.Description;
+
+	ImGui::PopID();
 }
 
-void ImGuiManager::Shutdown() {
-	if (!Initialized) return;
+static void RenderContent() {
+	if (SelectedSection.empty()) {
+		ImGui::TextDisabled("Select a section from the left panel.");
+		return;
+	}
 
-	SetOverlayVisible(false);
-	RestoreMouseVTable();
-	SetWindowLong(GameWindow, GWL_WNDPROC, (LONG)(LONG_PTR)OriginalWndProc);
+	SettingManager::Configuration::SettingList settings;
+	TheSettingManager->FillMenuSettings(&settings, SelectedSection.c_str());
 
-	ImGui_ImplDX9_Shutdown();
-	ImGui_ImplWin32_Shutdown();
-	ImGui::DestroyContext();
+	if (settings.empty()) {
+		ImGui::TextDisabled("No settings in this section.");
+		return;
+	}
 
-	Initialized = false;
-	Logger::Log("ImGuiManager: Shutdown");
+	HoveredDescription.clear();
+
+	ImGui::TextColored(ImVec4(1.0f, 0.85f, 0.45f, 1.0f), "%s", SelectedSection.c_str());
+	ImGui::Separator();
+	ImGui::Spacing();
+
+	for (auto& setting : settings)
+		RenderSetting(setting);
+
+	if (!HoveredDescription.empty()) {
+		ImGui::Spacing();
+		ImGui::Separator();
+		ImGui::TextWrapped("%s", HoveredDescription.c_str());
+	}
+}
+
+// Recursive sidebar tree — path is the full dotted section path, name is the display label.
+static void RenderSectionNode(const std::string& path, const std::string& name, bool parentIsShaders) {
+	StringList subsections;
+	TheSettingManager->FillMenuSections(&subsections, path.c_str());
+
+	bool isLeaf = subsections.empty();
+
+	if (isLeaf) {
+		bool selected = (SelectedSection == path);
+		if (ImGui::Selectable(name.c_str(), selected))
+			SelectedSection = path;
+		return;
+	}
+
+	// For shader entries (direct children of "Shaders"), show an inline enable toggle.
+	bool isShaderEntry = parentIsShaders;
+	bool open = false;
+
+	if (isShaderEntry) {
+		bool enabled = TheSettingManager->GetMenuShaderEnabled(name.c_str());
+		bool forced  = TheSettingManager->IsShaderForced(name.c_str());
+
+		ImGui::PushStyleColor(ImGuiCol_Text, enabled
+			? ImVec4(0.40f, 1.00f, 0.40f, 1.0f)
+			: ImVec4(0.55f, 0.55f, 0.55f, 1.0f));
+		open = ImGui::TreeNode(("##tn_" + name).c_str());
+		ImGui::PopStyleColor();
+
+		ImGui::SameLine();
+		ImGui::BeginDisabled(forced);
+		if (ImGui::Checkbox(name.c_str(), &enabled)) {
+			TheShaderManager->SwitchShaderStatus(name.c_str());
+			TheSettingManager->LoadSettings();
+		}
+		ImGui::EndDisabled();
+
+		if (forced) {
+			ImGui::SameLine();
+			ImGui::TextDisabled("(forced)");
+		}
+
+		// Show render time in debug mode
+		if (TheSettingManager->SettingsMain.Develop.DebugMode) {
+			EffectRecord* effect = TheShaderManager->GetEffectByName(name.c_str());
+			if (effect) {
+				float total = max(effect->renderTime + effect->constantUpdateTime, 0.0f);
+				if (!TheSettingManager->SettingsMain.Main.RenderEffects) total = 0.0f;
+				std::stringstream ss;
+				ss << std::fixed << std::setprecision(3) << total << " ms";
+				ImGui::SameLine();
+				ImGui::TextDisabled("%s", ss.str().c_str());
+			}
+		}
+	} else {
+		open = ImGui::TreeNode(name.c_str());
+	}
+
+	if (open) {
+		bool childrenAreShaders = (path == "Shaders");
+		for (auto& sub : subsections)
+			RenderSectionNode(path + "." + sub, sub, childrenAreShaders);
+		ImGui::TreePop();
+	}
+}
+
+static void RenderSidebar() {
+	StringList topSections;
+	TheSettingManager->FillMenuSections(&topSections, nullptr);
+	for (auto& section : topSections)
+		RenderSectionNode(section, section, false);
+}
+
+static void RenderMainMenuToast() {
+	static auto startTime = std::chrono::system_clock::now();
+	auto elapsed = std::chrono::duration<double>(std::chrono::system_clock::now() - startTime).count();
+	if (elapsed > 5.0) return;
+
+	std::string msg = std::string(PluginVersion::VersionString)
+		+ " loaded  |  press "
+		+ TheGameMenuManager->GetKeyName(TheSettingManager->SettingsMain.Menu.KeyEnable)
+		+ " to open settings";
+
+	ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+	ImVec2 textSize    = ImGui::CalcTextSize(msg.c_str());
+	ImVec2 pos         = ImVec2((displaySize.x - textSize.x) * 0.5f, displaySize.y - textSize.y - 12.0f);
+
+	ImGui::GetForegroundDrawList()->AddText(
+		ImVec2(pos.x + 1, pos.y + 1),
+		IM_COL32(0, 0, 0, 200),
+		msg.c_str());
+	ImGui::GetForegroundDrawList()->AddText(
+		pos,
+		IM_COL32(220, 220, 220, 255),
+		msg.c_str());
+}
+
+void ImGuiManager::BuildUI() {
+	// Main menu: show toast only, no settings window
+	if (InterfaceManager->IsActive(Menu::MenuType::kMenuType_Main)) {
+		RenderMainMenuToast();
+		return;
+	}
+
+	if (!Visible) return;
+
+	ImGui::SetNextWindowSize(ImVec2(960.0f, 620.0f), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSizeConstraints(ImVec2(500.0f, 300.0f), ImVec2(FLT_MAX, FLT_MAX));
+
+	ImGuiWindowFlags flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+	if (!ImGui::Begin("New Vegas Reloaded", nullptr, flags)) {
+		ImGui::End();
+		return;
+	}
+
+	// Toolbar row
+	if (TheSettingManager->hasUnsavedChanges)
+		ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.2f, 1.0f), "/!\\ Unsaved changes");
+	else
+		ImGui::TextDisabled("New Vegas Reloaded  %s", PluginVersion::VersionString);
+
+	ImGui::SameLine(ImGui::GetContentRegionAvail().x - 54.0f + ImGui::GetCursorPosX()
+		- ImGui::GetContentRegionAvail().x + ImGui::GetContentRegionAvail().x - 54.0f);
+	if (ImGui::Button("Save", ImVec2(54.0f, 0.0f))) {
+		TheSettingManager->SaveSettings();
+		InterfaceManager->ShowMessage("Settings saved.");
+	}
+
+	ImGui::Separator();
+
+	// Two-panel layout
+	float sidebarW = 260.0f;
+	float contentH = ImGui::GetContentRegionAvail().y;
+
+	ImGui::BeginChild("##sidebar", ImVec2(sidebarW, contentH), true);
+	RenderSidebar();
+	ImGui::EndChild();
+
+	ImGui::SameLine();
+
+	ImGui::BeginChild("##content", ImVec2(0.0f, contentH), true);
+	RenderContent();
+	ImGui::EndChild();
+
+	ImGui::End();
 }

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -9,66 +9,70 @@
 
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
+typedef HRESULT(WINAPI* GetDeviceState_t)(IDirectInputDevice8*, DWORD, LPVOID);
+static GetDeviceState_t OriginalGetDeviceState = nullptr;
+
 bool    ImGuiManager::Initialized     = false;
 bool    ImGuiManager::Visible         = false;
 bool    ImGuiManager::DeviceLost      = false;
 HWND    ImGuiManager::GameWindow      = nullptr;
 WNDPROC ImGuiManager::OriginalWndProc = nullptr;
 
-static int         CursorShowDelta    = 0;
 static std::string SelectedSection;
 static std::string HoveredDescription;
 static bool        InFileDialog       = false;
 
-// Flags we disable on the player while the overlay is open.
-static constexpr UInt32 kOverlayControlFlags =
-	TogglePlayerControlsAlt::kFlag_Movement   |
-	TogglePlayerControlsAlt::kFlag_Looking    |
-	TogglePlayerControlsAlt::kFlag_Fighting   |
-	TogglePlayerControlsAlt::kFlag_Attacking  |
-	TogglePlayerControlsAlt::kFlag_AimingOrBlocking |
-	TogglePlayerControlsAlt::kFlag_EnterVATS  |
-	TogglePlayerControlsAlt::kFlag_Jumping    |
-	TogglePlayerControlsAlt::kFlag_POV;
+// ---- DirectInput mouse block (zeros lX/lY/lZ deltas + buttons) ---------------
+// xNVSE has no public API to block mouse movement deltas, so we patch the
+// IDirectInputDevice8 vtable directly.  The hook is installed once and never
+// removed; it simply passes through when the overlay is not visible.
 
-// ---- xNVSE input block -------------------------------------------------------
+static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
+	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
+	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
+		memset(lpvData, 0, cbData);
+	return hr;
+}
+
+static void** GetMouseVTable() {
+	InputControl* input = Global->GetInputControl();
+	if (!input || !input->mouseInterface) return nullptr;
+	return *reinterpret_cast<void***>(input->mouseInterface);
+}
+
+static void PatchMouseVTable() {
+	void** vtable = GetMouseVTable();
+	if (!vtable) return;
+	if (vtable[9] == reinterpret_cast<void*>(HookedGetDeviceState)) return;
+	OriginalGetDeviceState = reinterpret_cast<GetDeviceState_t>(vtable[9]);
+	DWORD old;
+	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &old);
+	vtable[9] = reinterpret_cast<void*>(HookedGetDeviceState);
+	VirtualProtect(&vtable[9], sizeof(void*), old, &old);
+}
+
+// ---- xNVSE input block (mouse buttons / wheel via DIHookControl) -------------
 
 static void BlockGameInput(bool block) {
-	// Block/unblock all mouse buttons and wheel via DIHookControl so clicks and
-	// scroll events don't reach the game while the overlay is open.
 	if (g_DIHookCtrl) {
 		for (UInt32 code = kMacro_MouseButtonOffset; code < kMaxMacros; code++)
 			g_DIHookCtrl->SetKeyDisableState(code, block, DIHookControl::kDisable_User);
 	}
-
-	// Disable/enable player controls (camera, movement, etc.) so the character
-	// doesn't react to mouse deltas or WASD while the overlay is open.
-	if (g_PlayerControls) {
-		if (block)
-			g_PlayerControls->DisablePlayerControlsAlt(kOverlayControlFlags, "NVR");
-		else
-			g_PlayerControls->EnablePlayerControlsAlt(kOverlayControlFlags, "NVR");
-	}
 }
 
-// ---- Cursor / visibility -----------------------------------------------------
+// ---- Visibility --------------------------------------------------------------
 
 static void SetOverlayVisible(bool visible) {
 	if (ImGuiManager::IsVisible() == visible) return;
 	ImGuiManager::SetVisible(visible);
 	if (visible) {
-		// ShowCursor uses a reference counter; track every TRUE call so we can
-		// undo exactly that many FALSE calls on hide.
-		CursorShowDelta = 0;
-		int count;
-		do { count = ShowCursor(TRUE); CursorShowDelta++; } while (count < 0);
 		ClipCursor(nullptr);
 		BlockGameInput(true);
+		ImGui::GetIO().MouseDrawCursor = true;
 		ImGui::GetIO().ClearInputKeys();
 	} else {
 		BlockGameInput(false);
-		for (int i = 0; i < CursorShowDelta; i++) ShowCursor(FALSE);
-		CursorShowDelta = 0;
+		ImGui::GetIO().MouseDrawCursor = false;
 	}
 }
 
@@ -89,17 +93,8 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 			ImGui::GetIO().AddInputCharacterUTF16(buf[i]);
 	}
 
-	if (Visible) {
-		if (ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
-			return TRUE;
-		// When the overlay is open, keep the cursor visible everywhere in the window.
-		// ImGui only handles WM_SETCURSOR when the mouse is over one of its windows;
-		// if the mouse is in the game viewport the original WndProc would hide it.
-		if (msg == WM_SETCURSOR) {
-			SetCursor(LoadCursor(nullptr, IDC_ARROW));
-			return TRUE;
-		}
-	}
+	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
+		return TRUE;
 	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
 }
 
@@ -131,6 +126,7 @@ void ImGuiManager::Initialize() {
 	ImGui_ImplDX9_Init(device);
 
 	OriginalWndProc = (WNDPROC)SetWindowLong(hwnd, GWL_WNDPROC, (LONG)(LONG_PTR)WndProc);
+	PatchMouseVTable();
 
 	Initialized = true;
 	Logger::Log("ImGuiManager: Initialized");
@@ -160,6 +156,7 @@ void ImGuiManager::NewFrame() {
 	if (DeviceLost && coop == D3DERR_DEVICENOTRESET) {
 		ImGui_ImplDX9_CreateDeviceObjects();
 		DeviceLost = false;
+		PatchMouseVTable();
 	}
 
 	// Close if a game menu is active (inventory, pip-boy, etc.)

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -443,6 +443,7 @@ void ImGuiManager::BuildUI() {
 			InFileDialog = true;
 			bool ok = GetSaveFileNameA(&ofn) != 0;
 			InFileDialog = false;
+			SetForegroundWindow(GameWindow);
 			SetOverlayVisible(true);
 			if (ok)
 				TheSettingManager->SaveSettingsTo(path);

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -4,6 +4,7 @@
 #include "imgui_impl_win32.h"
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
 #include <commdlg.h>
 #pragma comment(lib, "comdlg32.lib")
 
@@ -103,6 +104,10 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 
 	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
 		return TRUE;
+	// WndProcHandler returns 0 for scroll messages, so eat them explicitly to
+	// prevent the game's WndProc from interfering with ImGui child-window scroll.
+	if (Visible && (msg == WM_MOUSEWHEEL || msg == WM_MOUSEHWHEEL))
+		return 0;
 	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
 }
 
@@ -228,10 +233,18 @@ static void RenderSetting(SettingManager::Configuration::ConfigNode& node) {
 		break;
 	}
 	default: {
-		char buf[80];
-		strncpy_s(buf, node.Value, sizeof(buf));
-		if (ImGui::InputText(node.Key, buf, sizeof(buf), ImGuiInputTextFlags_EnterReturnsTrue)) {
-			TheSettingManager->SetSettingS(node.Section, node.Key, buf);
+		// A plain local buf reset from node.Value each frame causes ImGui to detect
+		// an external buffer change and reset the in-progress edit every frame.
+		// Use a persistent buffer per widget ID, only refreshed when not editing.
+		static std::unordered_map<ImGuiID, std::array<char, 80>> sBufs;
+		ImGuiID id = ImGui::GetID(node.Key);
+		auto& buf = sBufs[id];
+		if (ImGui::GetActiveID() != id)
+			strncpy_s(buf.data(), buf.size(), node.Value, _TRUNCATE);
+		if (ImGui::InputText(node.Key, buf.data(), buf.size()))
+			; // ImGui writes back to buf each frame while active; commit on focus loss
+		if (ImGui::IsItemDeactivatedAfterEdit()) {
+			TheSettingManager->SetSettingS(node.Section, node.Key, buf.data());
 			TheSettingManager->LoadSettings();
 		}
 		break;

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -68,7 +68,10 @@ static void SetOverlayVisible(bool visible) {
 		CursorShowDelta = 0;
 		while (ShowCursor(TRUE) < 0) CursorShowDelta++;
 		ClipCursor(nullptr);
+		PatchMouseVTable();           // re-patch in case DI device was recreated
+		ImGui::GetIO().ClearInputKeys();  // discard any stale key state
 	} else {
+		RestoreMouseVTable();
 		for (int i = 0; i < CursorShowDelta; i++) ShowCursor(FALSE);
 		CursorShowDelta = 0;
 	}

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -3,14 +3,53 @@
 #include "imgui_impl_dx9.h"
 #include "imgui_impl_win32.h"
 
-// Forward declaration from imgui_impl_win32 — not exposed in the public header
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+// Original GetDeviceState from the mouse DirectInput device vtable (index 9)
+typedef HRESULT(WINAPI* GetDeviceState_t)(IDirectInputDevice8*, DWORD, LPVOID);
+static GetDeviceState_t OriginalGetDeviceState = nullptr;
 
 bool    ImGuiManager::Initialized     = false;
 bool    ImGuiManager::Visible         = false;
 bool    ImGuiManager::DeviceLost      = false;
 HWND    ImGuiManager::GameWindow      = nullptr;
 WNDPROC ImGuiManager::OriginalWndProc = nullptr;
+
+// Intercepts the game's mouse DirectInput read. When the overlay is open,
+// zero the result so camera movement and button presses don't reach the game.
+static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
+	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
+	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
+		memset(lpvData, 0, cbData);
+	return hr;
+}
+
+static void PatchMouseVTable() {
+	InputControl* input = Global->GetInputControl();
+	if (!input || !input->mouseInterface) return;
+
+	void** vtable = *reinterpret_cast<void***>(input->mouseInterface);
+	OriginalGetDeviceState = reinterpret_cast<GetDeviceState_t>(vtable[9]);
+
+	DWORD oldProtect;
+	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &oldProtect);
+	vtable[9] = reinterpret_cast<void*>(HookedGetDeviceState);
+	VirtualProtect(&vtable[9], sizeof(void*), oldProtect, &oldProtect);
+}
+
+static void RestoreMouseVTable() {
+	if (!OriginalGetDeviceState) return;
+
+	InputControl* input = Global->GetInputControl();
+	if (!input || !input->mouseInterface) return;
+
+	void** vtable = *reinterpret_cast<void***>(input->mouseInterface);
+
+	DWORD oldProtect;
+	VirtualProtect(&vtable[9], sizeof(void*), PAGE_READWRITE, &oldProtect);
+	vtable[9] = reinterpret_cast<void*>(OriginalGetDeviceState);
+	VirtualProtect(&vtable[9], sizeof(void*), oldProtect, &oldProtect);
+}
 
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
@@ -46,6 +85,8 @@ void ImGuiManager::Initialize() {
 
 	OriginalWndProc = (WNDPROC)SetWindowLong(hwnd, GWL_WNDPROC, (LONG)(LONG_PTR)WndProc);
 
+	PatchMouseVTable();
+
 	Initialized = true;
 	Logger::Log("ImGuiManager: Initialized");
 }
@@ -56,7 +97,6 @@ void ImGuiManager::NewFrame() {
 		if (!Initialized) return;
 	}
 
-	// Handle device lost/reset so we never submit draw calls with a dead device
 	HRESULT coop = TheRenderManager->device->TestCooperativeLevel();
 	if (coop == D3DERR_DEVICELOST) {
 		if (!DeviceLost) {
@@ -70,15 +110,14 @@ void ImGuiManager::NewFrame() {
 		DeviceLost = false;
 	}
 
-	// F11 toggles the overlay as a placeholder; Step 6 replaces this
-	// with the configured activation key from SettingManager.
 	if (GetAsyncKeyState(VK_F11) & 1) {
 		Visible = !Visible;
+		// ShowCursor is reference-counted — loop until the cursor is actually shown/hidden
 		if (Visible) {
-			ShowCursor(TRUE);
+			while (ShowCursor(TRUE) < 0) {}
 			ClipCursor(nullptr);
 		} else {
-			ShowCursor(FALSE);
+			while (ShowCursor(FALSE) >= 0) {}
 		}
 	}
 
@@ -106,6 +145,7 @@ void ImGuiManager::BuildUI() {
 void ImGuiManager::Shutdown() {
 	if (!Initialized) return;
 
+	RestoreMouseVTable();
 	SetWindowLong(GameWindow, GWL_WNDPROC, (LONG)(LONG_PTR)OriginalWndProc);
 
 	ImGui_ImplDX9_Shutdown();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -102,7 +102,7 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 		return TRUE;
 	}
 
-	if (Visible && msg == WM_KEYDOWN && ImGui::GetIO().WantTextInput) {
+	if (Visible && msg == WM_KEYDOWN) {
 		BYTE ks[256];
 		GetKeyboardState(ks);
 		WCHAR buf[4] = {};

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -72,8 +72,15 @@ void ImGuiManager::NewFrame() {
 
 	// F11 toggles the overlay as a placeholder; Step 6 replaces this
 	// with the configured activation key from SettingManager.
-	if (GetAsyncKeyState(VK_F11) & 1)
+	if (GetAsyncKeyState(VK_F11) & 1) {
 		Visible = !Visible;
+		if (Visible) {
+			ShowCursor(TRUE);
+			ClipCursor(nullptr);
+		} else {
+			ShowCursor(FALSE);
+		}
+	}
 
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -259,14 +259,17 @@ static void RenderSectionNode(const std::string& path, const std::string& name, 
 
 	bool isLeaf = subsections.empty();
 
+	// Scope all widget IDs to this node's unique path.
+	ImGui::PushID(path.c_str());
+
 	if (isLeaf) {
 		bool selected = (SelectedSection == path);
 		if (ImGui::Selectable(name.c_str(), selected))
 			SelectedSection = path;
+		ImGui::PopID();
 		return;
 	}
 
-	// For shader entries (direct children of "Shaders"), show an inline enable toggle.
 	bool isShaderEntry = parentIsShaders;
 	bool open = false;
 
@@ -277,7 +280,7 @@ static void RenderSectionNode(const std::string& path, const std::string& name, 
 		ImGui::PushStyleColor(ImGuiCol_Text, enabled
 			? ImVec4(0.40f, 1.00f, 0.40f, 1.0f)
 			: ImVec4(0.55f, 0.55f, 0.55f, 1.0f));
-		open = ImGui::TreeNode(("##tn_" + name).c_str());
+		open = ImGui::TreeNode("##node");
 		ImGui::PopStyleColor();
 
 		ImGui::SameLine();
@@ -306,7 +309,7 @@ static void RenderSectionNode(const std::string& path, const std::string& name, 
 			}
 		}
 	} else {
-		open = ImGui::TreeNode(("##" + path).c_str());
+		open = ImGui::TreeNode("##node");
 		ImGui::SameLine();
 		ImGui::TextUnformatted(name.c_str());
 	}
@@ -317,6 +320,8 @@ static void RenderSectionNode(const std::string& path, const std::string& name, 
 			RenderSectionNode(path + "." + sub, sub, childrenAreShaders);
 		ImGui::TreePop();
 	}
+
+	ImGui::PopID();
 }
 
 static void RenderSidebar() {

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -51,7 +51,21 @@ static void RestoreMouseVTable() {
 	VirtualProtect(&vtable[9], sizeof(void*), oldProtect, &oldProtect);
 }
 
+static void SetOverlayVisible(bool visible) {
+	if (ImGuiManager::IsVisible() == visible) return;
+	ImGuiManager::SetVisible(visible);
+	if (visible) {
+		while (ShowCursor(TRUE) < 0) {}
+		ClipCursor(nullptr);
+	} else {
+		while (ShowCursor(FALSE) >= 0) {}
+	}
+}
+
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE)
+		SetOverlayVisible(false);
+
 	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
 		return TRUE;
 	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
@@ -110,16 +124,8 @@ void ImGuiManager::NewFrame() {
 		DeviceLost = false;
 	}
 
-	if (GetAsyncKeyState(VK_F11) & 1) {
-		Visible = !Visible;
-		// ShowCursor is reference-counted — loop until the cursor is actually shown/hidden
-		if (Visible) {
-			while (ShowCursor(TRUE) < 0) {}
-			ClipCursor(nullptr);
-		} else {
-			while (ShowCursor(FALSE) >= 0) {}
-		}
-	}
+	if (GetAsyncKeyState(VK_F11) & 1)
+		SetOverlayVisible(!Visible);
 
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();
@@ -154,6 +160,7 @@ void ImGuiManager::BuildUI() {
 void ImGuiManager::Shutdown() {
 	if (!Initialized) return;
 
+	SetOverlayVisible(false);
 	RestoreMouseVTable();
 	SetWindowLong(GameWindow, GWL_WNDPROC, (LONG)(LONG_PTR)OriginalWndProc);
 

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -103,10 +103,12 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 	}
 
 	if (Visible && msg == WM_KEYDOWN) {
+		Logger::Log("ImGui WM_KEYDOWN vk=%u", (unsigned)wParam);
 		BYTE ks[256];
 		GetKeyboardState(ks);
 		WCHAR buf[4] = {};
 		int n = ToUnicode((UINT)wParam, (lParam >> 16) & 0xFF, ks, buf, 4, 0);
+		Logger::Log("ImGui ToUnicode n=%d", n);
 		for (int i = 0; i < n; i++)
 			ImGui::GetIO().AddInputCharacterUTF16(buf[i]);
 	}

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -29,7 +29,10 @@ static bool        InFileDialog       = false;
 
 static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
 	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
-	if (SUCCEEDED(hr) && ImGuiManager::IsVisible())
+	// Only zero mouse-sized buffers (DIMOUSESTATE2 = 20 bytes).  The keyboard
+	// device shares this vtable in dinput8.dll and calls GetDeviceState(256, ...);
+	// passing that through unchanged keeps OnKeyDown/OnKeyPressed working.
+	if (SUCCEEDED(hr) && ImGuiManager::IsVisible() && cbData == sizeof(DIMOUSESTATE2))
 		memset(lpvData, 0, cbData);
 	return hr;
 }
@@ -84,6 +87,11 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 
 	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
 	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
+	if (Visible && msg == WM_KEYDOWN && wParam == VK_ESCAPE) {
+		SetOverlayVisible(false);
+		return TRUE;
+	}
+
 	if (Visible && msg == WM_KEYDOWN && ImGui::GetIO().WantTextInput) {
 		BYTE ks[256];
 		GetKeyboardState(ks);
@@ -382,8 +390,10 @@ void ImGuiManager::BuildUI() {
 	ImGui::SetNextWindowSizeConstraints(ImVec2(500.0f, 300.0f), ImVec2(FLT_MAX, FLT_MAX));
 
 	ImGuiWindowFlags flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
-	if (!ImGui::Begin("New Vegas Reloaded", nullptr, flags)) {
+	bool open = true;
+	if (!ImGui::Begin("New Vegas Reloaded", &open, flags) || !open) {
 		ImGui::End();
+		if (!open) SetOverlayVisible(false);
 		return;
 	}
 

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -20,7 +20,6 @@ HWND    ImGuiManager::GameWindow      = nullptr;
 WNDPROC ImGuiManager::OriginalWndProc = nullptr;
 
 static std::string SelectedSection;
-static std::string HoveredDescription;
 static bool        InFileDialog       = false;
 
 // ---- DirectInput mouse block (zeros lX/lY/lZ deltas + buttons) ---------------
@@ -254,8 +253,13 @@ static void RenderSetting(SettingManager::Configuration::ConfigNode& node) {
 	}
 	}
 
-	if (ImGui::IsItemHovered() && !node.Description.empty())
-		HoveredDescription = node.Description;
+	if (ImGui::IsItemHovered() && !node.Description.empty()) {
+		ImGui::BeginTooltip();
+		ImGui::PushTextWrapPos(ImGui::GetFontSize() * 28.0f);
+		ImGui::TextUnformatted(node.Description.c_str());
+		ImGui::PopTextWrapPos();
+		ImGui::EndTooltip();
+	}
 
 	ImGui::PopID();
 }
@@ -274,8 +278,6 @@ static void RenderContent() {
 		return;
 	}
 
-	HoveredDescription.clear();
-
 	ImGui::TextColored(ImVec4(1.0f, 0.85f, 0.45f, 1.0f), "%s", SelectedSection.c_str());
 	ImGui::Separator();
 	ImGui::Spacing();
@@ -283,11 +285,7 @@ static void RenderContent() {
 	for (auto& setting : settings)
 		RenderSetting(setting);
 
-	if (!HoveredDescription.empty()) {
-		ImGui::Spacing();
-		ImGui::Separator();
-		ImGui::TextWrapped("%s", HoveredDescription.c_str());
-	}
+
 }
 
 // Recursive sidebar tree — path is the full dotted section path, name is the display label.

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -65,8 +65,11 @@ static void SetOverlayVisible(bool visible) {
 	if (ImGuiManager::IsVisible() == visible) return;
 	ImGuiManager::SetVisible(visible);
 	if (visible) {
+		// ShowCursor uses a reference counter; we need to track every TRUE call
+		// so we can undo exactly that many FALSE calls on hide.
 		CursorShowDelta = 0;
-		while (ShowCursor(TRUE) < 0) CursorShowDelta++;
+		int count;
+		do { count = ShowCursor(TRUE); CursorShowDelta++; } while (count < 0);
 		ClipCursor(nullptr);
 		PatchMouseVTable();
 		ImGui::GetIO().ClearInputKeys();
@@ -93,8 +96,17 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 			ImGui::GetIO().AddInputCharacterUTF16(buf[i]);
 	}
 
-	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
-		return TRUE;
+	if (Visible) {
+		if (ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
+			return TRUE;
+		// When the overlay is open, keep the cursor visible everywhere in the window.
+		// ImGui only handles WM_SETCURSOR when the mouse is over one of its windows;
+		// if the mouse is in the game viewport the original WndProc would hide it.
+		if (msg == WM_SETCURSOR) {
+			SetCursor(LoadCursor(nullptr, IDC_ARROW));
+			return TRUE;
+		}
+	}
 	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
 }
 

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -27,14 +27,19 @@ static bool        InFileDialog       = false;
 // IDirectInputDevice8 vtable directly.  The hook is installed once and never
 // removed; it simply passes through when the overlay is not visible.
 
+static float s_pendingWheelDelta = 0.0f;
+
 static HRESULT WINAPI HookedGetDeviceState(IDirectInputDevice8* device, DWORD cbData, LPVOID lpvData) {
 	HRESULT hr = OriginalGetDeviceState(device, cbData, lpvData);
 	if (SUCCEEDED(hr) && ImGuiManager::IsVisible()) {
 		if (cbData == sizeof(DIMOUSESTATE2)) {
+			// Capture scroll wheel delta before zeroing so we can feed it to ImGui.
+			// WM_MOUSEWHEEL is suppressed by DXVK so WndProc never sees it.
+			s_pendingWheelDelta += ((DIMOUSESTATE2*)lpvData)->lZ / (float)WHEEL_DELTA;
 			memset(lpvData, 0, cbData);
 		} else if (cbData == 256) {
-			// Zero all keyboard keys except the toggle key so OnKeyDown can still
-			// detect it to close the overlay, while movement/actions are blocked.
+			// Zero keyboard buffer to block game movement/actions.
+			// Preserve the toggle key so OnKeyDown can still close the overlay.
 			BYTE toggleKey = TheSettingManager
 				? (BYTE)TheSettingManager->SettingsMain.Menu.KeyEnable : 0;
 			BYTE toggleState = toggleKey ? ((BYTE*)lpvData)[toggleKey] : 0;
@@ -102,18 +107,7 @@ LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 		return TRUE;
 	}
 
-	if (Visible && msg == WM_KEYDOWN) {
-		Logger::Log("ImGui WM_KEYDOWN vk=%u", (unsigned)wParam);
-		BYTE ks[256];
-		GetKeyboardState(ks);
-		WCHAR buf[4] = {};
-		int n = ToUnicode((UINT)wParam, (lParam >> 16) & 0xFF, ks, buf, 4, 0);
-		Logger::Log("ImGui ToUnicode n=%d", n);
-		for (int i = 0; i < n; i++)
-			ImGui::GetIO().AddInputCharacterUTF16(buf[i]);
-	}
-
-	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
+if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
 		return TRUE;
 	// WndProcHandler returns 0 for scroll messages, so eat them explicitly to
 	// prevent the game's WndProc from interfering with ImGui child-window scroll.
@@ -167,6 +161,77 @@ void ImGuiManager::Shutdown() {
 	Logger::Log("ImGuiManager: Shutdown");
 }
 
+// ---- Input polling (DXVK suppresses WM_KEYDOWN/WM_MOUSEWHEEL) ---------------
+
+static ImGuiKey VkToImGuiKey(int vk) {
+	switch (vk) {
+	case VK_TAB:      return ImGuiKey_Tab;
+	case VK_LEFT:     return ImGuiKey_LeftArrow;
+	case VK_RIGHT:    return ImGuiKey_RightArrow;
+	case VK_UP:       return ImGuiKey_UpArrow;
+	case VK_DOWN:     return ImGuiKey_DownArrow;
+	case VK_PRIOR:    return ImGuiKey_PageUp;
+	case VK_NEXT:     return ImGuiKey_PageDown;
+	case VK_HOME:     return ImGuiKey_Home;
+	case VK_END:      return ImGuiKey_End;
+	case VK_INSERT:   return ImGuiKey_Insert;
+	case VK_DELETE:   return ImGuiKey_Delete;
+	case VK_BACK:     return ImGuiKey_Backspace;
+	case VK_RETURN:   return ImGuiKey_Enter;
+	case VK_ESCAPE:   return ImGuiKey_Escape;
+	case VK_LSHIFT:   return ImGuiKey_LeftShift;
+	case VK_RSHIFT:   return ImGuiKey_RightShift;
+	case VK_LCONTROL: return ImGuiKey_LeftCtrl;
+	case VK_RCONTROL: return ImGuiKey_RightCtrl;
+	case VK_LMENU:    return ImGuiKey_LeftAlt;
+	case VK_RMENU:    return ImGuiKey_RightAlt;
+	case 'A': return ImGuiKey_A;
+	case 'C': return ImGuiKey_C;
+	case 'V': return ImGuiKey_V;
+	case 'X': return ImGuiKey_X;
+	case 'Z': return ImGuiKey_Z;
+	default:          return ImGuiKey_None;
+	}
+}
+
+static void PollKeyboardForImGui() {
+	static bool prevState[256] = {};
+	ImGuiIO& io = ImGui::GetIO();
+
+	// Build keyboard state for ToUnicode using async values for modifiers.
+	BYTE ks[256] = {};
+	GetKeyboardState(ks);
+	auto abit = [](int vk) -> BYTE { return (GetAsyncKeyState(vk) & 0x8000) ? 0x80 : 0; };
+	ks[VK_SHIFT]   = abit(VK_SHIFT);
+	ks[VK_CONTROL] = abit(VK_CONTROL);
+	ks[VK_MENU]    = abit(VK_MENU);
+	ks[VK_CAPITAL] = (GetKeyState(VK_CAPITAL) & 1) ? 0x01 : 0;
+
+	for (int vk = 1; vk < 256; vk++) {
+		// Skip generic aliases — we handle left/right variants explicitly.
+		if (vk == VK_SHIFT || vk == VK_CONTROL || vk == VK_MENU) continue;
+
+		bool cur  = (GetAsyncKeyState(vk) & 0x8000) != 0;
+		bool prev = prevState[vk];
+
+		// Inject key state transitions for navigation/modifier keys.
+		ImGuiKey key = VkToImGuiKey(vk);
+		if (key != ImGuiKey_None && cur != prev)
+			io.AddKeyEvent(key, cur);
+
+		// Inject printable character on fresh press.
+		if (cur && !prev) {
+			UINT scan = MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+			WCHAR buf[4] = {};
+			int n = ToUnicode(vk, scan, ks, buf, 4, 0);
+			for (int i = 0; i < n; i++)
+				io.AddInputCharacterUTF16(buf[i]);
+		}
+
+		prevState[vk] = cur;
+	}
+}
+
 // ---- Frame -------------------------------------------------------------------
 
 void ImGuiManager::NewFrame() {
@@ -201,6 +266,11 @@ void ImGuiManager::NewFrame() {
 		io.AddMouseButtonEvent(0, (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0);
 		io.AddMouseButtonEvent(1, (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0);
 		io.AddMouseButtonEvent(2, (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0);
+		if (s_pendingWheelDelta != 0.0f) {
+			io.AddMouseWheelEvent(0.0f, s_pendingWheelDelta);
+			s_pendingWheelDelta = 0.0f;
+		}
+		PollKeyboardForImGui();
 	}
 }
 

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -76,6 +76,18 @@ static void SetOverlayVisible(bool visible) {
 LRESULT CALLBACK ImGuiManager::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (msg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE)
 		SetOverlayVisible(false);
+
+	// FNV doesn't call TranslateMessage so WM_CHAR is never posted.
+	// Manually convert WM_KEYDOWN to characters when ImGui needs text input.
+	if (Visible && msg == WM_KEYDOWN && ImGui::GetIO().WantTextInput) {
+		BYTE ks[256];
+		GetKeyboardState(ks);
+		WCHAR buf[4] = {};
+		int n = ToUnicode((UINT)wParam, (lParam >> 16) & 0xFF, ks, buf, 4, 0);
+		for (int i = 0; i < n; i++)
+			ImGui::GetIO().AddInputCharacterUTF16(buf[i]);
+	}
+
 	if (Visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
 		return TRUE;
 	return CallWindowProc(OriginalWndProc, hwnd, msg, wParam, lParam);
@@ -189,20 +201,18 @@ static void RenderSetting(SettingManager::Configuration::ConfigNode& node) {
 	}
 	case NodeType::Float: {
 		float val = (float)atof(node.Value);
-		if (ImGui::DragFloat(node.Key, &val, 0.001f, 0.0f, 0.0f, "%.4f"))
-			if (ImGui::IsItemDeactivatedAfterEdit()) {
-				TheSettingManager->SetSetting(node.Section, node.Key, val);
-				TheSettingManager->LoadSettings();
-			}
+		if (ImGui::DragFloat(node.Key, &val, 0.001f, 0.0f, 0.0f, "%.4f")) {
+			TheSettingManager->SetSetting(node.Section, node.Key, val);
+			TheSettingManager->LoadSettings();
+		}
 		break;
 	}
 	case NodeType::Integer: {
 		int val = atoi(node.Value);
-		if (ImGui::DragInt(node.Key, &val, 1.0f))
-			if (ImGui::IsItemDeactivatedAfterEdit()) {
-				TheSettingManager->SetSetting(node.Section, node.Key, val);
-				TheSettingManager->LoadSettings();
-			}
+		if (ImGui::DragInt(node.Key, &val, 1.0f)) {
+			TheSettingManager->SetSetting(node.Section, node.Key, val);
+			TheSettingManager->LoadSettings();
+		}
 		break;
 	}
 	default: {

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -4,6 +4,8 @@
 #include "imgui_impl_win32.h"
 #include <sstream>
 #include <iomanip>
+#include <commdlg.h>
+#pragma comment(lib, "comdlg32.lib")
 
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
@@ -389,11 +391,35 @@ void ImGuiManager::BuildUI() {
 	else
 		ImGui::TextDisabled("New Vegas Reloaded  %s", PluginVersion::VersionString);
 
-	ImGui::SameLine(ImGui::GetContentRegionAvail().x - 54.0f + ImGui::GetCursorPosX()
-		- ImGui::GetContentRegionAvail().x + ImGui::GetContentRegionAvail().x - 54.0f);
-	if (ImGui::Button("Save", ImVec2(54.0f, 0.0f))) {
-		TheSettingManager->SaveSettings();
-		InterfaceManager->ShowMessage("Settings saved.");
+	{
+		const float btnRevert = 54.0f, btnSaveTo = 72.0f, btnSave = 54.0f;
+		const float spacing   = ImGui::GetStyle().ItemSpacing.x;
+		const float totalW    = btnRevert + btnSaveTo + btnSave + spacing * 2.0f;
+		ImGui::SameLine(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - totalW);
+
+		if (ImGui::Button("Revert", ImVec2(btnRevert, 0.0f))) {
+			TheSettingManager->RevertSettings();
+			SelectedSection.clear();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Save to...", ImVec2(btnSaveTo, 0.0f))) {
+			char path[MAX_PATH] = "NewVegasReloaded.dll.toml";
+			OPENFILENAMEA ofn   = {};
+			ofn.lStructSize     = sizeof(ofn);
+			ofn.hwndOwner       = GameWindow;
+			ofn.lpstrFilter     = "TOML Files\0*.toml\0All Files\0*.*\0";
+			ofn.lpstrFile       = path;
+			ofn.nMaxFile        = MAX_PATH;
+			ofn.lpstrDefExt     = "toml";
+			ofn.Flags           = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
+			if (GetSaveFileNameA(&ofn))
+				TheSettingManager->SaveSettingsTo(path);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Save", ImVec2(btnSave, 0.0f))) {
+			TheSettingManager->SaveSettings();
+			InterfaceManager->ShowMessage("Settings saved.");
+		}
 	}
 
 	ImGui::Separator();

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -546,6 +546,8 @@ void ImGuiManager::BuildUI() {
 			bool ok = GetSaveFileNameA(&ofn) != 0;
 			InFileDialog = false;
 			SetForegroundWindow(GameWindow);
+			ClipCursor(nullptr);
+			ImGui::GetIO().ClearInputKeys();
 			SetOverlayVisible(true);
 			if (ok)
 				TheSettingManager->SaveSettingsTo(path);

--- a/src/core/ImGuiManager.cpp
+++ b/src/core/ImGuiManager.cpp
@@ -68,10 +68,9 @@ static void SetOverlayVisible(bool visible) {
 		CursorShowDelta = 0;
 		while (ShowCursor(TRUE) < 0) CursorShowDelta++;
 		ClipCursor(nullptr);
-		PatchMouseVTable();           // re-patch in case DI device was recreated
-		ImGui::GetIO().ClearInputKeys();  // discard any stale key state
+		PatchMouseVTable();
+		ImGui::GetIO().ClearInputKeys();
 	} else {
-		RestoreMouseVTable();
 		for (int i = 0; i < CursorShowDelta; i++) ShowCursor(FALSE);
 		CursorShowDelta = 0;
 	}

--- a/src/core/ImGuiManager.h
+++ b/src/core/ImGuiManager.h
@@ -1,0 +1,21 @@
+#pragma once
+
+class ImGuiManager {
+public:
+	static void		Initialize();
+	static void		NewFrame();
+	static void		Render();
+	static void		Shutdown();
+
+	static bool		IsVisible() { return Visible; }
+
+private:
+	static bool		Initialized;
+	static bool		Visible;
+	static bool		DeviceLost;
+	static HWND		GameWindow;
+	static WNDPROC	OriginalWndProc;
+
+	static LRESULT CALLBACK	WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+	static void				BuildUI();
+};

--- a/src/core/ImGuiManager.h
+++ b/src/core/ImGuiManager.h
@@ -8,6 +8,7 @@ public:
 	static void		Shutdown();
 
 	static bool		IsVisible() { return Visible; }
+	static void		SetVisible(bool visible) { Visible = visible; }
 
 private:
 	static bool		Initialized;

--- a/src/core/SettingManager.cpp
+++ b/src/core/SettingManager.cpp
@@ -1,27 +1,33 @@
 #define TOML11_PRESERVE_COMMENTS_BY_DEFAULT
 
+// GetCurrentDirectoryA is reliable at startup but GetSaveFileNameA (and other
+// common-dialog calls) can silently change it.  Capture the game root once and
+// reuse it everywhere config paths are built.
+static const char* GetConfigBase() {
+	static char base[MAX_PATH] = {};
+	if (!base[0]) GetCurrentDirectoryA(MAX_PATH, base);
+	return base;
+}
+
+static void BuildConfigPath(char (&out)[MAX_PATH], const char* suffix) {
+	strcpy(out, GetConfigBase());
+	strcat(out, suffix);
+}
+
 /*
 * The Config Class holds, accesses and maintains the current instance of config document and its keys.
 */
 void SettingManager::Configuration::Init() {
 
-	char TomlFilename[MAX_PATH];
-	char DefaultsFilename[MAX_PATH];
+	char TomlFilename[MAX_PATH], DefaultsFilename[MAX_PATH];
+	BuildConfigPath(TomlFilename,     TomlSettingsFile);
+	BuildConfigPath(DefaultsFilename, DefaultsSettingsFile);
 
 	configLoaded = false;
-	GetCurrentDirectoryA(MAX_PATH, TomlFilename);
-	GetCurrentDirectoryA(MAX_PATH, DefaultsFilename);
-	strcat(TomlFilename, TomlSettingsFile);
-	strcat(DefaultsFilename, DefaultsSettingsFile);
 
 	try {
 		Logger::Log("Loading defaults from file %s", DefaultsFilename);
 		DefaultConfig = toml::parse<toml::preserve_comments, std::map>((std::string_view)DefaultsFilename).as_table();
-
-		//// log config file contents
-		//std::stringstream buffer;
-		//buffer << DefaultConfig << std::endl;
-		//Logger::Log("%s", buffer.str().c_str());
 	}
 	catch (const std::exception& e) {
 		Logger::Log("error loading defaults toml: %s", e.what());
@@ -30,12 +36,6 @@ void SettingManager::Configuration::Init() {
 	try {
 		Logger::Log("Loading settings from file %s", TomlFilename);
 		TomlConfig = toml::parse<toml::discard_comments, std::map>((std::string_view)TomlFilename).as_table();
-
-		//// log config file contents
-		//std::stringstream buffer;
-		//buffer << toml::format(TomlConfig, /*width = */ 0, /*prec = */ 4) << std::endl;
-		//Logger::Log("%s", buffer.str().c_str());
-
 	}
 	catch(const std::exception& e){
 		Logger::Log("error loading toml: %s, new config will be created from defaults.", e.what());
@@ -690,9 +690,7 @@ void SettingManager::GetFormList(const char* SectionName, FormsList* SettingList
 void SettingManager::SaveSettings() {
 
 	char Filename[MAX_PATH];
-
-	GetCurrentDirectoryA(MAX_PATH, Filename);
-	strcat(Filename, TomlSettingsFile);
+	BuildConfigPath(Filename, TomlSettingsFile);
 	std::ofstream ConfigurationFile(Filename, std::ios::trunc | std::ios::binary);
 
 	// log config file contents

--- a/src/core/SettingManager.cpp
+++ b/src/core/SettingManager.cpp
@@ -191,6 +191,7 @@ void SettingManager::Configuration::FillSections(StringList* Sections, const cha
 	Sections->clear();
 
 	for (const auto& [key, value] : sectionsTable->as_table()) {
+		if (!value.is_table()) continue; // skip leaf settings, only return sub-sections
 		const char* name = key.c_str();
 		//if (!memcmp(name, "Status", 6)) continue; // Ignore status subsections (TODO: breaks Menu, needs fixing)
 		if (!memcmp(name, "_", 1)) name = name + 1; //discard first "_"
@@ -229,9 +230,10 @@ void SettingManager::Configuration::FillSettings(SettingList* Nodes, const char*
 
 	Nodes->clear();
 	for (const auto& [key, value] : settingsTable->as_table()) {
+		if (value.is_table()) continue; // skip sub-sections, only return leaf settings
 		ConfigNode Node;
-		FillNode(&Node, Section, key.data());
-		Nodes->push_back(Node);
+		if (FillNode(&Node, Section, key.data()))
+			Nodes->push_back(Node);
 	}
 }
 

--- a/src/core/SettingManager.cpp
+++ b/src/core/SettingManager.cpp
@@ -706,6 +706,18 @@ void SettingManager::SaveSettings() {
 	hasUnsavedChanges = false;
 }
 
+void SettingManager::RevertSettings() {
+	Config.Init();
+	LoadSettings();
+	hasUnsavedChanges = false;
+}
+
+void SettingManager::SaveSettingsTo(const char* Path) {
+	std::ofstream file(Path, std::ios::trunc | std::ios::binary);
+	file << Config.TomlConfig << std::endl;
+	file.close();
+}
+
 int SettingManager::GetSettingI(const char* Section, const char* Key) {
 	Configuration::ConfigNode Node;
 	int Value = 0; //default in case the setting doesn't exist

--- a/src/core/SettingManager.cpp
+++ b/src/core/SettingManager.cpp
@@ -709,6 +709,19 @@ void SettingManager::SaveSettings() {
 void SettingManager::RevertSettings() {
 	Config.Init();
 	LoadSettings();
+
+	// Sync runtime shader Enabled flags — UpdateSettings() never touches them,
+	// only SwitchShaderStatus does, so we must fix them up after a config reload.
+	StringList shaders;
+	FillMenuSections(&shaders, "Shaders");
+	for (const auto& name : shaders) {
+		bool want = GetMenuShaderEnabled(name.c_str());
+		EffectRecord* effect = TheShaderManager->GetEffectByName(name.c_str());
+		if (effect) { effect->Enabled = want; continue; }
+		ShaderCollection* shader = TheShaderManager->GetShaderCollectionByName(name.c_str());
+		if (shader) shader->Enabled = want;
+	}
+
 	hasUnsavedChanges = false;
 }
 

--- a/src/core/SettingManager.h
+++ b/src/core/SettingManager.h
@@ -339,6 +339,8 @@ public:
 	static void				Initialize();
 	void					LoadSettings();
 	void					SaveSettings();
+	void					RevertSettings();
+	void					SaveSettingsTo(const char* Path);
 	int						GetSettingI(const char* Section, const char* Key);
 	float					GetSettingF(const char* Section, const char* Key);
 	char*					GetSettingS(const char* Section, const char* Key, char* Value);

--- a/src/core/ShaderManager.cpp
+++ b/src/core/ShaderManager.cpp
@@ -371,7 +371,7 @@ void ShaderManager::UpdateConstants() {
 	timer.LogTime("ShaderManager::UpdateConstants for generic constants");
 
 	if (TheSettingManager->SettingsChanged) {
-		TheGameMenuManager->UpdateSettings();
+		// TheGameMenuManager->UpdateSettings(); — replaced by ImGui overlay
 
 		// update settings
 		for (const auto [Name, effect] : EffectsNames) {


### PR DESCRIPTION
ImGui settings overlay integration

Adds a fully functional in-game settings overlay built on ImGui (DX9 + Win32 backend). Key features:

Live settings editing with hover tooltips, auto-populated from SettingManager
"Save Copy" button creates a timestamped backup next to the DLL, tagged with worldspace, cell name, and grid coordinates
Input fully functional under DXVK: keyboard via GetAsyncKeyState polling, scroll wheel via DirectInput mouse buffer, mouse buttons via GetAsyncKeyState
Input blocking when overlay is open (DI hook zeros mouse/keyboard buffers)
Escape closes overlay without leaking the keypress to the game
Version bumped to 4.4.0a (Unofficial)